### PR TITLE
CLIMATE-382 - Fix UI backend content type issues

### DIFF
--- a/ocw-ui/backend/local_file_metadata_extractors.py
+++ b/ocw-ui/backend/local_file_metadata_extractors.py
@@ -115,9 +115,8 @@ def list_latlon(file_path):
     else:
         output = {'success': success, 'variables': var_names_list}
 
-    output = json.dumps(output)
     if request.query.callback:
-        return '%s(%s)' % (request.query.callback, output)
+        return '%s(%s)' % (request.query.callback, json.dumps(output))
     return output
 
 @lfme_app.route('/list_time/<file_path:path>')
@@ -178,9 +177,8 @@ def list_time(file_path):
     else:
         output = {'success': False, 'variables': var_names_list}
 
-    output = json.dumps(output)
     if request.query.callback:
-        return '%s(%s)' % (request.query.callback, output)
+        return '%s(%s)' % (request.query.callback, json.dumps(output))
     return output
 
 @lfme_app.route('/list_vars/<file_path:path>')
@@ -219,9 +217,8 @@ def list_vars(file_path):
         output = {'success': True, 'variables': in_file.variables.keys()}
         in_file.close()
     finally:
-        output = json.dumps(output)
         if request.query.callback:
-          return "%s(%s)" % (request.query.callback, output)
+            return "%s(%s)" % (request.query.callback, json.dumps(output))
         return output
 
 @lfme_app.hook('after_request')

--- a/ocw-ui/backend/tests/test_local_file_metadata_extractors.py
+++ b/ocw-ui/backend/tests/test_local_file_metadata_extractors.py
@@ -1,5 +1,5 @@
 import os
-from ast import literal_eval
+from json import loads
 import unittest
 from webtest import TestApp
 
@@ -46,7 +46,7 @@ class TestLatLonExtraction(unittest.TestCase):
         # and check for proper content.
         callback = json[:json.index('(')]
         json = json[json.index('(') + 1 : json.rindex(')')]
-        json = literal_eval(json)
+        json = loads(json)
 
         self.assertDictEqual(expected_return, json)
         self.assertEqual(callback, "test_callback")
@@ -78,7 +78,7 @@ class TestLatLonExtraction(unittest.TestCase):
         # and check for proper content.
         callback = json[:json.index('(')]
         json = json[json.index('(') + 1 : json.rindex(')')]
-        json = literal_eval(json)
+        json = loads(json)
 
         self.assertDictEqual(expected_return, json)
         self.assertEqual(callback, "test_callback")
@@ -115,7 +115,7 @@ class TestTimeExtraction(unittest.TestCase):
         # and check for proper content.
         callback = json[:json.index('(')]
         json = json[json.index('(') + 1 : json.rindex(')')]
-        json = literal_eval(json)
+        json = loads(json)
 
         self.assertDictEqual(expected_return, json)
         self.assertEqual(callback, "test_callback")
@@ -147,7 +147,7 @@ class TestTimeExtraction(unittest.TestCase):
         # and check for proper content.
         callback = json[:json.index('(')]
         json = json[json.index('(') + 1 : json.rindex(')')]
-        json = literal_eval(json)
+        json = loads(json)
 
         self.assertDictEqual(expected_return, json)
         self.assertEqual(callback, "test_callback")
@@ -180,7 +180,7 @@ class TestVariableExtraction(unittest.TestCase):
         # and check for proper content.
         callback = json[:json.index('(')]
         json = json[json.index('(') + 1 : json.rindex(')')]
-        json = literal_eval(json)
+        json = loads(json)
 
         self.assertDictEqual(expected_return, json)
         self.assertEqual(callback, "test_callback")
@@ -202,7 +202,7 @@ class TestVariableExtraction(unittest.TestCase):
         # and check for proper content.
         callback = json[:json.index('(')]
         json = json[json.index('(') + 1 : json.rindex(')')]
-        json = literal_eval(json)
+        json = loads(json)
 
         self.assertDictEqual(expected_return, json)
         self.assertEqual(callback, "test_callback")


### PR DESCRIPTION
- Stop parsing JSON with ast.literal_eval in tests. Replace with the more
  correct json.loads.
- json.dumps is no longer called on all output JSON. When returning
  plain JSON this was causing the content type to be incorrectly set as
  text. Now json.dumps is only called when returning a JSONP response so
  we have the dictionary properly serialized. Bottle handles
  automatically setting the content type when returning a dictionary, so
  we don't need to manually set the content-type.
