### PR TITLE
CLIMATE-390 - Fix broken map layers

### DIFF
--- a/ocw-ui/frontend/app/js/directives/LeafletMap.js
+++ b/ocw-ui/frontend/app/js/directives/LeafletMap.js
@@ -32,8 +32,7 @@ App.Directives.directive('leafletMap', function($rootScope) {
 				worldCopyJump: true,
 			});
 
-			//create a CloudMade tile layer and add it to the map
-			L.tileLayer('http://{s}.tile.cloudmade.com/57cbb6ca8cac418dbb1a402586df4528/997/256/{z}/{x}/{y}.png', {}).addTo($rootScope.map);
+			L.tileLayer('http://{s}.tile.osm.org/{z}/{x}/{y}.png', {}).addTo($rootScope.map);
 		}
 	};
 });

--- a/ocw-ui/frontend/app/js/directives/PreviewMap.js
+++ b/ocw-ui/frontend/app/js/directives/PreviewMap.js
@@ -39,8 +39,7 @@ App.Directives.directive('previewMap', function($rootScope) {
 					worldCopyJump: true,
 				});
 
-				//create a CloudMade tile layer and add it to the map
-				L.tileLayer('http://{s}.tile.cloudmade.com/57cbb6ca8cac418dbb1a402586df4528/997/256/{z}/{x}/{y}.png', {}).addTo(map);
+				L.tileLayer('http://{s}.tile.osm.org/{z}/{x}/{y}.png', {}).addTo(map);
 
 				// Zoom the map to the dataset bound regions (or at least try our best to do so)
 				var datasetBounds = [[scope.dataset.latlonVals.latMax, scope.dataset.latlonVals.lonMin], 


### PR DESCRIPTION
- The URL for the map tile layer that the Leaflet and Preview map
  directives were using is no longer valid. It has been replaced with a
  new one from the LeafletJS website.
