### PR TITLE
CLIMATE-391 - Normalize evaluation time values in OCW UI

### DIFF
--- a/ocw-ui/backend/processing.py
+++ b/ocw-ui/backend/processing.py
@@ -173,12 +173,28 @@ def run_evaluation():
                        for ds in target_datasets]
 
     # Subset the datasets
+    start = eval_bounds['start_time']
+    end = eval_bounds['end_time']
+
+    # Normalize all the values to the first of the month if we're not
+    # dealing with daily data. This will ensure that a valid subregion
+    # isn't considered out of bounds do to a dataset's time values
+    # being shifted to the first of the month.
+    if time_step != 'daily':
+        if start.day != 1:
+            day_offset = start.day - 1
+            start -= timedelta(days=day_offset)
+
+        if end.day != 1:
+            day_offset = end.day - 1
+            end -= timedelta(days=day_offset)
+
     subset = Bounds(eval_bounds['lat_min'],
                     eval_bounds['lat_max'],
                     eval_bounds['lon_min'],
                     eval_bounds['lon_max'],
-                    eval_bounds['start_time'],
-                    eval_bounds['end_time'])
+                    start,
+                    end)
 
     ref_dataset = dsp.subset(subset, ref_dataset)
     target_datasets = [dsp.subset(subset, ds)


### PR DESCRIPTION
- Date values that are passed for an evaluation are now normalized so
  all the day values are 1 unless the evaluation is handling daily data.
