### PR TITLE
CLIMATE-397 - Switch UI backend over to safe_subset

### DIFF
--- a/ocw-ui/backend/processing.py
+++ b/ocw-ui/backend/processing.py
@@ -196,8 +196,8 @@ def run_evaluation():
                     start,
                     end)
 
-    ref_dataset = dsp.subset(subset, ref_dataset)
-    target_datasets = [dsp.subset(subset, ds)
+    ref_dataset = dsp.safe_subset(subset, ref_dataset)
+    target_datasets = [dsp.safe_subset(subset, ds)
                        for ds
                        in target_datasets]
     


### PR DESCRIPTION
- The UI backend now uses dataset_processor.safe_subset instead of
  subset when it performs subsetting tasks on the loaded datasets. This
  helps to ensure that RCMED datasets don't wind up causing problems due
  to fractional lat/lon grids.
