### PR TITLE
CLIMATE-399 - Use functions in numpy.testing for unit tests involving array comparisons

### DIFF
--- a/ocw/tests/test_dataset.py
+++ b/ocw/tests/test_dataset.py
@@ -96,11 +96,11 @@ class TestInvalidDatasetInit(unittest.TestCase):
         values = flat_array.reshape(len(times), len(lats), len(bad_lons))
 
         ds = Dataset(lats, bad_lons, times, values)
-        self.assertTrue(np.array_equal(ds.lons, np.arange(-180, 180)))
+        np.testing.assert_array_equal(ds.lons, np.arange(-180, 180))
     
     def test_reversed_lats(self):
         ds = Dataset(self.lat[::-1], self.lon, self.time, self.value)
-        self.assertTrue(np.array_equal(ds.lats, self.lat))
+        np.testing.assert_array_equal(ds.lats, self.lat)
 
 class TestDatasetFunctions(unittest.TestCase):
     def setUp(self):

--- a/ocw/tests/test_dataset_processor.py
+++ b/ocw/tests/test_dataset_processor.py
@@ -28,12 +28,7 @@ import numpy.ma as ma
 import logging
 logging.basicConfig(level=logging.CRITICAL)
 
-class CustomAssertions:
-    # Custom Assertions to handle Numpy Arrays
-    def assert1DArraysEqual(self, array1, array2):
-        self.assertSequenceEqual(tuple(array1), tuple(array2))
-
-class TestEnsemble(unittest.TestCase, CustomAssertions): 
+class TestEnsemble(unittest.TestCase): 
     def test_unequal_dataset_shapes(self):
         self.ten_year_dataset = ten_year_monthly_dataset()
         self.two_year_dataset = two_year_daily_dataset()
@@ -51,7 +46,7 @@ class TestEnsemble(unittest.TestCase, CustomAssertions):
         self.ensemble = dp.ensemble(self.datasets)
         self.ensemble_flat = self.ensemble.values.flatten()
         self.three_flat = self.three.values.flatten()
-        self.assert1DArraysEqual(self.ensemble_flat, self.three_flat)
+        np.testing.assert_array_equal(self.ensemble_flat, self.three_flat)
     
     def test_ensemble_name(self):
         self.ensemble_dataset_name = "Dataset Ensemble"
@@ -62,7 +57,7 @@ class TestEnsemble(unittest.TestCase, CustomAssertions):
         self.assertEquals(self.ensemble.name, self.ensemble_dataset_name)
         
 
-class TestTemporalRebin(unittest.TestCase, CustomAssertions):
+class TestTemporalRebin(unittest.TestCase):
     
     def setUp(self):
         self.ten_year_monthly_dataset = ten_year_monthly_dataset()
@@ -71,7 +66,7 @@ class TestTemporalRebin(unittest.TestCase, CustomAssertions):
     
     def test_monthly_to_annual_rebin(self):
         annual_dataset = dp.temporal_rebin(self.ten_year_monthly_dataset, datetime.timedelta(days=365))
-        self.assert1DArraysEqual(annual_dataset.times, self.ten_year_annual_times)
+        np.testing.assert_array_equal(annual_dataset.times, self.ten_year_annual_times)
     
     def test_monthly_to_full_rebin(self):
         full_dataset = dp.temporal_rebin(self.ten_year_monthly_dataset, datetime.timedelta(days=3650))
@@ -84,21 +79,21 @@ class TestTemporalRebin(unittest.TestCase, CustomAssertions):
         bins = list(set([datetime.datetime(time_reading.year, time_reading.month, 1) for time_reading in self.two_years_daily_dataset.times]))
         bins = np.array(bins)
         bins.sort()
-        self.assert1DArraysEqual(monthly_dataset.times, bins)
+        np.testing.assert_array_equal(monthly_dataset.times, bins)
     
     def test_daily_to_annual_rebin(self):
         annual_dataset = dp.temporal_rebin(self.two_years_daily_dataset, datetime.timedelta(days=366))
         bins = list(set([datetime.datetime(time_reading.year, 1, 1) for time_reading in self.two_years_daily_dataset.times]))
         bins = np.array(bins)
         bins.sort()
-        self.assert1DArraysEqual(annual_dataset.times, bins)
+        np.testing.assert_array_equal(annual_dataset.times, bins)
     
     def test_non_rebin(self):
         """This will take a monthly dataset and ask for a monthly rebin of 28 days.  The resulting
         dataset should have the same time values"""
         monthly_dataset = dp.temporal_rebin(self.ten_year_monthly_dataset, datetime.timedelta(days=28))
         good_times = self.ten_year_monthly_dataset.times
-        self.assert1DArraysEqual(monthly_dataset.times, good_times)
+        np.testing.assert_array_equal(monthly_dataset.times, good_times)
 
     def test_variable_propagation(self):
         annual_dataset = dp.temporal_rebin(self.ten_year_monthly_dataset,
@@ -135,7 +130,7 @@ class TestRcmesSpatialRegrid(unittest.TestCase):
         self.assertEqual(regridded_values.shape, lats2.shape)
         self.assertEqual(regridded_values.shape, lons2.shape)
 
-class TestSpatialRegrid(unittest.TestCase, CustomAssertions):
+class TestSpatialRegrid(unittest.TestCase):
     
     def setUp(self):
         self.input_dataset = ten_year_monthly_dataset()
@@ -145,10 +140,10 @@ class TestSpatialRegrid(unittest.TestCase, CustomAssertions):
 
 
     def test_returned_lats(self):
-        self.assert1DArraysEqual(self.regridded_dataset.lats, self.new_lats)
+        np.testing.assert_array_equal(self.regridded_dataset.lats, self.new_lats)
 
     def test_returned_lons(self):
-        self.assert1DArraysEqual(self.regridded_dataset.lons, self.new_lons)
+        np.testing.assert_array_equal(self.regridded_dataset.lons, self.new_lons)
 
     def test_shape_of_values(self):
         regridded_data_shape = self.regridded_dataset.values.shape
@@ -358,10 +353,10 @@ class TestNetCDFWrite(unittest.TestCase):
         new_ds = local.load_file(self.file_name, self.ds.variable)
 
         self.assertEqual(self.ds.variable, new_ds.variable)
-        self.assertTrue(np.array_equal(self.ds.lats, new_ds.lats))
-        self.assertTrue(np.array_equal(self.ds.lons, new_ds.lons))
-        self.assertTrue(np.array_equal(self.ds.times, new_ds.times))
-        self.assertTrue(np.array_equal(self.ds.values, new_ds.values))
+        np.testing.assert_array_equal(self.ds.lats, new_ds.lats)
+        np.testing.assert_array_equal(self.ds.lons, new_ds.lons)
+        np.testing.assert_array_equal(self.ds.times, new_ds.times)
+        np.testing.assert_array_equal(self.ds.values, new_ds.values)
 
 def ten_year_monthly_dataset():
     lats = np.array(range(-89, 90, 2))

--- a/ocw/tests/test_metrics.py
+++ b/ocw/tests/test_metrics.py
@@ -54,7 +54,7 @@ class TestBias(unittest.TestCase):
         '''Test bias function between reference dataset and target dataset.'''
         expected_result = np.zeros((12, 5, 5), dtype=np.int)
         expected_result.fill(-300)
-        self.assertTrue(np.array_equal(self.bias.run(self.reference_dataset, self.target_dataset), expected_result))
+        np.testing.assert_array_equal(self.bias.run(self.reference_dataset, self.target_dataset), expected_result)
 
 
 class TestTemporalStdDev(unittest.TestCase):

--- a/ocw/tests/test_utils.py
+++ b/ocw/tests/test_utils.py
@@ -101,15 +101,15 @@ class TestNormalizeLatLonValues(unittest.TestCase):
         lats, lons, values = utils.normalize_lat_lon_values(self.lats,
                                                             self.lons,
                                                             self.values)
-        self.assertTrue(np.array_equal(lons, np.arange(-180, 180)))
+        np.testing.assert_array_equal(lons, np.arange(-180, 180))
         
     def test_lats_reversed(self):
     	lons2 = np.arange(-180, 180)
         lats, lons, values = utils.normalize_lat_lon_values(self.lats[::-1],
                                                             lons2,
                                                             self.values[:, ::-1, :])
-        self.assertTrue(np.array_equal(lats, self.lats))
-        self.assertTrue(np.array_equal(values, self.values))
+        np.testing.assert_array_equal(lats, self.lats)
+        np.testing.assert_array_equal(values, self.values)
     
     def test_lons_shift_values(self):
         expected_vals = np.array([[2, 3, 0, 1],
@@ -118,7 +118,7 @@ class TestNormalizeLatLonValues(unittest.TestCase):
         lats, lons, values = utils.normalize_lat_lon_values(self.lats2,
                                                             self.lons2,
                                                             self.values2)
-        self.assertTrue(np.array_equal(values, expected_vals))
+        np.testing.assert_array_equal(values, expected_vals)
         
     def test_shift_and_reversed(self):
         expected_vals = np.array([[10, 11, 8, 9],
@@ -127,7 +127,7 @@ class TestNormalizeLatLonValues(unittest.TestCase):
         lats, lons, values = utils.normalize_lat_lon_values(self.lats2[::-1],
                                                             self.lons2,
                                                             self.values2)
-        self.assertTrue(np.array_equal(values, expected_vals))
+        np.testing.assert_array_equal(values, expected_vals)
         
     def test_lats_not_sorted(self):
         self.assertRaises(ValueError, 


### PR DESCRIPTION
This should slightly improve the robustness of our unit tests involving numpy array equality.
