### PR TITLE
CLIMATE-437 - Remove provision-er from Vagrantfile

### DIFF
--- a/ocw-vm/Vagrantfile
+++ b/ocw-vm/Vagrantfile
@@ -6,16 +6,11 @@ VAGRANTFILE_API_VERSION = "2"
 
 Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
     config.vm.box = "hashicorp/precise64"
-
-    config.vm.provision :shell, 
-        :privileged => false,
-        :path => "init-ocw-vm.sh"
-
-    # Boot the VM into GUI mode.
+    
+    #Boot the VM into GUI mode.
     config.vm.provider "virtualbox" do |vb|
         # Don't boot with headless mode
         vb.gui = true
-
         # Use VBoxManage to customize the VM. For example to change memory:
         vb.customize ["modifyvm", :id, "--memory", "1024"]
     end


### PR DESCRIPTION
- The VM init script requires some user input and the default Vagrant
  provisioner doesn't seem to allow for that. Until a better solution is
  found, the initialization script needs to be called manually after
  creating the new VM. Check the documentation on the OCW wiki at [1]
  for additional info.

[1] http://s.apache.org/Rxd
