### PR TITLE
CLIMATE-440 - Remove local PATH_LEADER settings in directory_helpers

### DIFF
--- a/ocw-ui/backend/tests/__init__.py
+++ b/ocw-ui/backend/tests/__init__.py
@@ -1,5 +1,6 @@
 import os
 from urllib import urlretrieve
+from ..config import WORK_DIR, PATH_LEADER
 
 FILE_LEADER = "http://zipper.jpl.nasa.gov/dist/"
 FILE_1 = "AFRICA_KNMI-RACMO2.2b_CTL_ERAINT_MM_50km_1989-2008_tasmax.nc"
@@ -12,5 +13,8 @@ def setup_package():
     if not os.path.exists('/tmp/d2.nc'):
         urlretrieve(FILE_LEADER + FILE_2, '/tmp/d2.nc')
 
-    if not os.path.exists('/tmp/ocw'):
-        os.mkdir('/tmp/ocw')
+    if not os.path.exists(WORK_DIR):
+        os.mkdir(WORK_DIR)
+
+    if not os.path.exists(PATH_LEADER):
+        os.mkdir(PATH_LEADER)

--- a/ocw-ui/backend/tests/test_directory_helpers.py
+++ b/ocw-ui/backend/tests/test_directory_helpers.py
@@ -21,30 +21,26 @@ import unittest
 from webtest import TestApp
 
 from ..run_webservices import app
+from ..config import WORK_DIR, PATH_LEADER
 from ..directory_helpers import _get_clean_directory_path
 
 test_app = TestApp(app)
-WORK_DIR = '/tmp/ocw'
 
 class TestDirectoryPathList(unittest.TestCase):
-    PATH_LEADER = '/usr/local/ocw'
-
     @classmethod
     def setUpClass(self):
-        if not os.path.exists(self.PATH_LEADER): os.mkdir(self.PATH_LEADER)
-        if not os.path.exists(self.PATH_LEADER + '/bar'):
-            os.mkdir(self.PATH_LEADER + '/bar')
-        if not os.path.exists(self.PATH_LEADER + '/baz.txt'):
-            open(self.PATH_LEADER + '/baz.txt', 'a').close()
-        if not os.path.exists(self.PATH_LEADER + '/test.txt'):
-            open(self.PATH_LEADER + '/test.txt', 'a').close()
+        if not os.path.exists(PATH_LEADER + '/bar'):
+            os.mkdir(PATH_LEADER + '/bar')
+        if not os.path.exists(PATH_LEADER + '/baz.txt'):
+            open(PATH_LEADER + '/baz.txt', 'a').close()
+        if not os.path.exists(PATH_LEADER + '/test.txt'):
+            open(PATH_LEADER + '/test.txt', 'a').close()
 
     @classmethod
     def tearDownClass(self):
-        os.remove(self.PATH_LEADER + '/test.txt')
-        os.remove(self.PATH_LEADER + '/baz.txt')
-        os.rmdir(self.PATH_LEADER + '/bar')
-        os.rmdir(self.PATH_LEADER)
+        os.remove(PATH_LEADER + '/test.txt')
+        os.remove(PATH_LEADER + '/baz.txt')
+        os.rmdir(PATH_LEADER + '/bar')
 
     def test_valid_path_listing(self):
         expected_return = {'listing': ['/bar/', '/baz.txt', '/test.txt']}
@@ -128,36 +124,33 @@ class TestResultResultRetrieval(unittest.TestCase):
         self.assertDictEqual(response_json, expected_return)
 
 class TestDirectoryPathCleaner(unittest.TestCase):
-    PATH_LEADER = '/tmp/foo'
-    VALID_CLEAN_DIR = '/tmp/foo/bar'
+    VALID_CLEAN_DIR = os.path.join(PATH_LEADER, 'bar')
 
     @classmethod
     def setUpClass(self):
-        if not os.path.exists(self.PATH_LEADER): os.mkdir(self.PATH_LEADER)
         if not os.path.exists(self.VALID_CLEAN_DIR): os.mkdir(self.VALID_CLEAN_DIR)
 
     @classmethod
     def tearDownClass(self):
         os.rmdir(self.VALID_CLEAN_DIR)
-        os.rmdir(self.PATH_LEADER)
 
     def test_valid_directory_path(self):
-        clean_path = _get_clean_directory_path(self.PATH_LEADER, '/bar')
+        clean_path = _get_clean_directory_path(PATH_LEADER, '/bar')
         self.assertEquals(clean_path, self.VALID_CLEAN_DIR)
 
     def test_duplicate_slash_removal(self):
-        clean_path = _get_clean_directory_path(self.PATH_LEADER, '//bar')
+        clean_path = _get_clean_directory_path(PATH_LEADER, '//bar')
         self.assertEquals(clean_path, self.VALID_CLEAN_DIR)
 
-        clean_path = _get_clean_directory_path(self.PATH_LEADER, '/////bar')
+        clean_path = _get_clean_directory_path(PATH_LEADER, '/////bar')
         self.assertEquals(clean_path, self.VALID_CLEAN_DIR)
 
     def test_relative_path_removal(self):
-        clean_path = _get_clean_directory_path(self.PATH_LEADER, '/../bar')
+        clean_path = _get_clean_directory_path(PATH_LEADER, '/../bar')
         self.assertEquals(clean_path, self.VALID_CLEAN_DIR)
 
-        clean_path = _get_clean_directory_path(self.PATH_LEADER, '/./bar')
+        clean_path = _get_clean_directory_path(PATH_LEADER, '/./bar')
         self.assertEquals(clean_path, self.VALID_CLEAN_DIR)
 
-        clean_path = _get_clean_directory_path(self.PATH_LEADER, '/.././bar')
+        clean_path = _get_clean_directory_path(PATH_LEADER, '/.././bar')
         self.assertEquals(clean_path, self.VALID_CLEAN_DIR)


### PR DESCRIPTION
- Remove all local copies of PATH_LEADER in test_directory_helpers. Now
  the settings in the backend config are used instead.
- Move PATH_LEADER creation to the test package wide setup function.
  Remove the explicit removes present in test_directory_helpers.
- Remove hardcoded WORK_DIR value in package wide setup function. Now
  the value set in config is used instead.
