### PR TITLE
CLIMATE-446 - Use archive link for Anaconda download

### DIFF
--- a/easy-ocw/install-ubuntu-12_04.sh
+++ b/easy-ocw/install-ubuntu-12_04.sh
@@ -140,7 +140,7 @@ read -p "Press [ENTER] to continue ..."
 
 cd
 task "Downloading Anaconda ..."
-wget -O Anaconda-1.9.2-Linux-x86_64.sh "http://09c8d0b2229f813c1b93-c95ac804525aac4b6dba79b00b39d1d3.r79.cf1.rackcdn.com/Anaconda-1.9.2-Linux-x86_64.sh" 2> install_log
+wget -O Anaconda-1.9.2-Linux-x86_64.sh "http://repo.continuum.io/archive/Anaconda-1.9.2-Linux-x86_64.sh" 2> install_log
 subtask "done"
 
 task "Installing ..."


### PR DESCRIPTION
Switch the Anaconda download link in the easy-ocw Ubuntu install script to use the Anaconda archive link from http://repo.continuum.io/archive/index.html
