### PR TITLE
CLIMATE-448 Use 'dateutil.relativedelta' to get 'next-month' datetime in...

### DIFF
--- a/ocw/utils.py
+++ b/ocw/utils.py
@@ -22,6 +22,7 @@ import datetime as dt
 import numpy as np
 
 from mpl_toolkits.basemap import shiftgrid
+from dateutil.relativedelta import relativedelta
 
 
 def decode_time_values(dataset, time_var_name):
@@ -50,8 +51,7 @@ def decode_time_values(dataset, time_var_name):
         # datetime.timedelta doesn't support a 'months' option. To remedy
         # this, a month == 30 days for our purposes.
         for time_val in time_data:
-            num_days = 30 * time_val
-            times.append(time_base + dt.timedelta(days=num_days))
+            times.append(time_base + relativedelta(months = int(time_val)))
     else:
         for time_val in time_data:
             arg[time_units] = time_val
@@ -112,7 +112,7 @@ def parse_time_base(time_format):
         '%Y:%m:%d:%H:%M:%S', '%Y-%m-%d-%H:%M:%S', '%Y-%m-%d %H:%M:%S',
         '%Y/%m/%d%H:%M:%S', '%Y-%m-%d %H:%M', '%Y/%m/%d %H:%M',
         '%Y:%m:%d %H:%M', '%Y%m%d %H:%M', '%Y-%m-%d', '%Y/%m/%d',
-        '%Y:%m:%d', '%Y%m%d', '%Y-%m-%d %H:%M:%S.%f'
+        '%Y:%m:%d', '%Y%m%d', '%Y-%m-%d %H:%M:%S.%f', '%Y-%m-%d %H'
     ]
 
     # Attempt to match the base time string with a possible format parsing string.


### PR DESCRIPTION
... 'decode_time_values' function.

I also added new time_base format to list '%Y-%m-%d %H'.
