### PR TITLE
CLIMATE-427 - Install pip dependencies from a requirements file

### DIFF
--- a/easy-ocw/install-osx.sh
+++ b/easy-ocw/install-osx.sh
@@ -174,34 +174,4 @@ echo | conda install --file ocw-conda-dependencies.txt
 # scipy, matplotlib, and basemap. For everything else, we stick
 # with pip.
 header "Installing additional Python packages"
-task "Installing requests ..."
-pip install requests >> install_log
-subtask "done"
-
-task "Installing bottle ..."
-pip install bottle >> install_log
-subtask "done"
-
-task "Installing pydap ..."
-pip install pydap >> install_log
-subtask "done"
-
-task "Installing webtest ..."
-pip install webtest >> install_log
-subtask "done"
-
-task "Installing nose ..."
-pip install nose >> install_log
-subtask "done"
-
-task "Installing pylint ..."
-pip install pylint >> install_log
-subtask "done"
-
-task "Installing sphinx ..."
-pip install sphinx==1.2.1 >> install_log
-subtask "done"
-
-task "Installing sphinxcontrib ..."
-pip install sphinxcontrib-httpdomain==1.2.1 >> install_log
-subtask "done"
+pip install -r ocw-pip-dependencies.txt >> install_log

--- a/easy-ocw/install-ubuntu-12_04.sh
+++ b/easy-ocw/install-ubuntu-12_04.sh
@@ -184,37 +184,7 @@ subtask "done"
 # can be installed with Conda, but since none of them have an annoying
 # compiled component we just installed them with Pip.
 header "Installing additional Python packages"
-task "Installing requests ..."
-pip install requests >> install_log
-subtask "done"
-
-task "Installing bottle ..."
-pip install bottle >> install_log
-subtask "done"
-
-task "Installing pydap ..."
-pip install pydap >> install_log
-subtask "done"
-
-task "Installing webtest ..."
-pip install webtest >> install_log
-subtask "done"
-
-task "Installing nose ..."
-pip install nose >> install_log
-subtask "done"
-
-task "Installing pylint ..."
-pip install pylint >> install_log
-subtask "done"
-
-task "Installing sphinx ..."
-pip install sphinx==1.2.1 >> install_log
-subtask "done"
-
-task "Installing sphinxcontrib ..."
-pip install sphinxcontrib-httpdomain==1.2.1 >> install_log
-subtask "done"
+pip install -r ocw-pip-dependencies.txt >> install_log
 
 # Ensure that the climate code is included in the Python Path
 header "Updating PYTHONPATH ..."

--- a/easy-ocw/ocw-pip-dependencies.txt
+++ b/easy-ocw/ocw-pip-dependencies.txt
@@ -1,0 +1,8 @@
+requests
+bottle
+pydap
+webtest
+nose
+pylint
+sphinx==1.2.1
+sphinxcontrib-httpdomain==1.2.1


### PR DESCRIPTION
- Add ocw-pip-dependencies.txt for tracking all pip installed
  dependencies needed in an Easy-OCW installation. Note that this
  doesn't include things such as virtualenv or virtualenvwrapper which
  are only installed if the user requests them. This only includes
  dependencies that are pip installed by both the OS X and Ubuntu
  install scripts.
- Update the OS X and Ubuntu install scripts to use the new requirements
  text for pip installation.
