### PR TITLE
CLIMATE-452 - Add Unity desktop option to VM Build

### DIFF
--- a/ocw-vm/init-ocw-vm.sh
+++ b/ocw-vm/init-ocw-vm.sh
@@ -32,9 +32,14 @@ sudo apt-get install -y vim
 
 # GUI related installs
 sudo apt-get install -y lightdm
+
+# XFCE
 sudo apt-get install -y xfce4
 sudo apt-get install -y xdg-utils
 sudo apt-get install -y eog
+
+# Ubuntu Unity
+#sudo apt-get install -y ubuntu-desktop
 
 # Use the Easy-OCW Ubuntu install script to get everything
 # else installed!


### PR DESCRIPTION
- Add Ubuntu Unity option to OCW VM Vagrant build. By default XFCE is
  installed. If a user wants Unity, they should comment out the XFCE
  section and uncomment the Unity section when building the machine. It
  should be noted that the Unity install takes longer, but it comes with
  a lot more stuff out of the box (including looking nicer in general).
