### PR TITLE
CLIMATE-454 - Copy over install dependencies during VM build

### DIFF
--- a/ocw-vm/init-ocw-vm.sh
+++ b/ocw-vm/init-ocw-vm.sh
@@ -39,5 +39,10 @@ sudo apt-get install -y eog
 # Use the Easy-OCW Ubuntu install script to get everything
 # else installed!
 git clone http://git-wip-us.apache.org/repos/asf/climate.git
+
+# Copy the Easy-OCW install script for Ubuntu
 cp climate/easy-ocw/install-ubuntu-12_04.sh .
+# Copy the requirements files for conda and pip used by Easy-OCW
+cp climate/easy-ocw/*.txt .
+
 bash install-ubuntu-12_04.sh -q


### PR DESCRIPTION
- The requirements files for pip and conda weren't being copied over
  during the VM build which was causing it to fail. The requirements
  files for both pip and conda are copied over now even though the conda
  one isn't used at the moment. In the future, it is planned that conda
  will be used instead of downloading an Anaconda Python distribution.
