### PR TITLE
CLIMATE-455 - Update reshape_monthly_to_annually to use copies of data

### DIFF
--- a/ocw/utils.py
+++ b/ocw/utils.py
@@ -231,7 +231,7 @@ def reshape_monthly_to_annually(dataset):
     :rtype: Numpy array
     '''
 
-    values = dataset.values
+    values = dataset.values[:]
     data_shape = values.shape
     num_total_month = data_shape[0]
     num_year = num_total_month / 12


### PR DESCRIPTION
- utils.reshape_monthly_to_annually now uses a copy of the passed
  dataset's data instead of the actual dataset.values array.
