### PR TITLE
CLIMATE-470 - Update time base parsing string with new format

### DIFF
--- a/ocw/utils.py
+++ b/ocw/utils.py
@@ -111,7 +111,7 @@ def parse_time_base(time_format):
         '%Y:%m:%d:%H:%M:%S', '%Y-%m-%d-%H:%M:%S', '%Y-%m-%d %H:%M:%S',
         '%Y/%m/%d%H:%M:%S', '%Y-%m-%d %H:%M', '%Y/%m/%d %H:%M',
         '%Y:%m:%d %H:%M', '%Y%m%d %H:%M', '%Y-%m-%d', '%Y/%m/%d',
-        '%Y:%m:%d', '%Y%m%d', '%Y-%m-%d %H:%M:%S.%f'
+        '%Y:%m:%d', '%Y%m%d', '%Y-%m-%d %H:%M:%S.%f', '%Y-%m-%d %H',
     ]
 
     # Attempt to match the base time string with a possible format parsing string.


### PR DESCRIPTION
- Add a new string format for time base parsing to handle date strings
  of the form "1999-1-1 0".
