### PR TITLE
CLIMATE-472 - Fix overlapping colorbar labels

### DIFF
--- a/ocw/plotter.py
+++ b/ocw/plotter.py
@@ -536,9 +536,10 @@ def draw_contour_map(dataset, lats, lons, fname, fmt='png', gridshape=(1, 1),
 
     # Add colorbar
     cbar = fig.colorbar(cs, cax=ax.cax, drawedges=True, orientation='horizontal',
-                        extendfrac='auto')
+                        extendfrac='auto', format='%.3e')
     cbar.set_label(clabel)
     cbar.set_ticks(clevs)
+    cbar.ax.tick_params(labelsize=6)
     cbar.ax.xaxis.set_ticks_position('none')
     cbar.ax.yaxis.set_ticks_position('none')
 
@@ -672,9 +673,11 @@ def draw_portrait_diagram(results, rowlabels, collabels, fname, fmt='png',
     # Add colorbar
     cax = ax.cax
     cbar = fig.colorbar(cs, cax=cax, norm=norm, boundaries=clevs, drawedges=True,
-                        extend=extend, orientation='horizontal', extendfrac='auto')
+                        extend=extend, orientation='horizontal', extendfrac='auto',
+                        format='%.2e')
     cbar.set_label(clabel)
     cbar.set_ticks(clevs)
+    cbar.ax.tick_params(labelsize=6)
     cbar.ax.xaxis.set_ticks_position('none')
     cbar.ax.yaxis.set_ticks_position('none')
 


### PR DESCRIPTION
- Switch colorbar labels to use scientific notation.
- Reduce labelsize to avoid overlap.
