### PR TITLE
CLIMATE-504, OCW cli cannot get observation spatial resolution

### DIFF
--- a/ocw-cli/ocw_cli.py
+++ b/ocw-cli/ocw_cli.py
@@ -605,8 +605,8 @@ def settings_screen(header):
      obs_temp_res = observations_info[0]['timestep']        #just accepts one obs at this time
      model_lat_res = model_datasets[0].spatial_resolution()[0] #just accepts one model at this time
      model_lon_res = model_datasets[0].spatial_resolution()[1]  #just accepts one model at this time
-     obs_lat_res = observations_info[0].observations_info['lat_res']     #just accepts one obs at this time
-     obs_lon_res = observations_info[0].observations_info['lon_res']    #just accepts one obs at this time
+     obs_lat_res = observations_info[0]['lat_res']     #just accepts one obs at this time
+     obs_lon_res = observations_info[0]['lon_res']    #just accepts one obs at this time
 
      temp_grid_option = "Observation"
      temp_grid_setting = obs_temp_res


### PR DESCRIPTION
Line 608 and 609 of OCW cli have wrong calling of dictionary to get the observation spatial resolution.
The right way is to get values of keys of 'lat_res' and 'lon_res'.
