### PR TITLE
CLIMATE-375 - Truncate long dataset names in DatasetDisplay

### DIFF
--- a/ocw-ui/frontend/app/styles/main.css
+++ b/ocw-ui/frontend/app/styles/main.css
@@ -46,6 +46,15 @@ body {
 	overflow-x: hidden;
 }
 
+.datasetNameDisplay {
+    max-width: 320px;
+    display: inline-block;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    padding-left: 0;
+}
+
 #ocw-navbar {
     margin-bottom: 0;
 }

--- a/ocw-ui/frontend/app/views/main.html
+++ b/ocw-ui/frontend/app/views/main.html
@@ -110,7 +110,7 @@ under the License.
             <div ng-repeat="dataset in datasets">
               <div class="row">
                 <!--Data section-->
-                <div class="col-md-8 col-md-offset-1 muted">
+                <div class="datasetNameDisplay col-md-8 col-md-offset-1 muted" tooltip="{{dataset.name}}">
                   {{dataset.name}}
                 </div>
                 <div class="col-md-1 col-md-offset-2">


### PR DESCRIPTION
- Long dataset names are now truncated down in the dataset display.
  This uses CSS to do the truncation based on row size. It could also be
  done with a filter but that was decided against due to the difficulty in
  associating a number of characters with a row width given the
  semi-dynamic nature of the layout.
