### PR TITLE
CLIMATE-517 - Fix start and end date layout overlap issues

### DIFF
--- a/ocw-ui/frontend/app/views/main.html
+++ b/ocw-ui/frontend/app/views/main.html
@@ -127,13 +127,9 @@ under the License.
                 <div class="col-md-9">
                   <div class="row">
                     <div class="col-md-2 col-md-offset-1 text-center">Start:</div>
-                    <div class="col-md-2">
-                      <div class="col-md-2 text-center">{{dataset.timeVals.start | ISODateToMiddleEndian}}</div>
-                    </div>
+                    <div class="col-md-2 text-center">{{dataset.timeVals.start | ISODateToMiddleEndian}}</div>
                     <div class="col-md-2 text-center">End:</div>
-                    <div class="col-md-2">
-                      <div class="col-md-2 text-center">{{dataset.timeVals.end | ISODateToMiddleEndian}}</div>
-                    </div>
+                    <div class="col-md-2 text-center">{{dataset.timeVals.end | ISODateToMiddleEndian}}</div>
                   </div>
                   <!--Lat/Long Values!-->
                   <div class="row">


### PR DESCRIPTION
- Fix the start and end date layout problems. An additional column
  wrapped around the display of the dates caused labels and values to
  overlap.
