### PR TITLE
Minor docstring fix, swap shape of Evaluation.results

### DIFF
--- a/ocw/evaluation.py
+++ b/ocw/evaluation.py
@@ -90,13 +90,13 @@ class Evaluation(object):
         self._subregions = subregions
 
         #: A list containing the results of running regular metric evaluations. 
-        #: The shape of results is ``(num_metrics, num_target_datasets)`` if
+        #: The shape of results is ``(num_target_datasets, num_metrics)`` if
         #: the user doesn't specify subregion information. Otherwise the shape
-        #: is ``(num_metrics, num_target_datasets, num_subregions)``.
+        #: is ``(num_target_datasets, num_metrics, num_subregions)``.
         self.results = []
         #: A list containing the results of running the unary metric 
         #: evaluations. The shape of unary_results is 
-        #: ``(num_metrics, num_targets)`` where ``num_targets = 
+        #: ``(num_targets, num_metrics)`` where ``num_targets = 
         #: num_target_ds + (1 if ref_dataset != None else 0``
         self.unary_results = []
 


### PR DESCRIPTION
When I was developing the model ensemble to RCMED example script I stumbled on this documentation bug.  Big thanks to @MJJoyce for helping me dig into the code and find the issue.
