### PR TITLE
CLIMATE-597 - Subsetting a dataset should update the names attribute

### DIFF
--- a/ocw/dataset_processor.py
+++ b/ocw/dataset_processor.py
@@ -152,7 +152,7 @@ def ensemble(datasets):
     
     return ensemble_dataset
 
-def subset(subregion, target_dataset):
+def subset(subregion, target_dataset, subregion_name=None):
     '''Subset given dataset(s) with subregion information
 
     :param subregion: The Bounds with which to subset the target Dataset. 
@@ -160,6 +160,9 @@ def subset(subregion, target_dataset):
 
     :param target_dataset: The Dataset object to subset.
     :type target_dataset: :class:`dataset.Dataset`
+
+    :param subregion_name: The subset-ed Dataset name
+    :type subregion_name: :mod:`string`
 
     :returns: The subset-ed Dataset object
     :rtype: :class:`dataset.Dataset`
@@ -172,6 +175,9 @@ def subset(subregion, target_dataset):
 
     # Get subregion indices into subregion data
     dataset_slices = _get_subregion_slice_indices(subregion, target_dataset)
+
+    if not subregion_name:
+        subregion_name = target_dataset.name
 
     # Build new dataset with subset information
     return ds.Dataset(
@@ -191,11 +197,11 @@ def subset(subregion, target_dataset):
             dataset_slices["lon_start"]:dataset_slices["lon_end"] + 1],
         variable=target_dataset.variable,
         units=target_dataset.units,
-        name=target_dataset.name,
+        name=subregion_name,
         origin=target_dataset.origin
     )
 
-def safe_subset(subregion, target_dataset):
+def safe_subset(subregion, target_dataset, subregion_name=None):
     '''Safely subset given dataset with subregion information
 
     A standard subset requires that the provided subregion be entirely contained
@@ -207,6 +213,9 @@ def safe_subset(subregion, target_dataset):
 
     :param target_dataset: The Dataset object to subset.
     :type target_dataset: :class:`dataset.Dataset`
+
+    :param subregion_name: The subset-ed Dataset name
+    :type subregion_name: :mod:`string`
 
     :returns: The subset-ed Dataset object
     :rtype: :class:`dataset.Dataset`
@@ -233,7 +242,7 @@ def safe_subset(subregion, target_dataset):
     if subregion.end > end:
         subregion.end = end
 
-    return subset(subregion, target_dataset)
+    return subset(subregion, target_dataset, subregion_name)
 
 def normalize_dataset_datetimes(dataset, timestep):
     ''' Normalize Dataset datetime values.

--- a/ocw/tests/test_dataset_processor.py
+++ b/ocw/tests/test_dataset_processor.py
@@ -174,6 +174,7 @@ class TestNormalizeDatasetDatetimes(unittest.TestCase):
 class TestSubset(unittest.TestCase):
     def setUp(self):
         self.target_dataset = ten_year_monthly_dataset()
+        self.name = 'foo'
 
         self.subregion = ds.Bounds(
             -81, 81, 
@@ -202,7 +203,16 @@ class TestSubset(unittest.TestCase):
         self.assertEqual(subset.lons.shape[0], 162)
         self.assertEqual(subset.times.shape[0], 37)
         self.assertEqual(subset.values.shape, (37, 82, 162))
-    
+
+    def test_subset_name(self):
+        subset = dp.subset(self.subregion, self.target_dataset)
+        self.assertEqual(subset.name, self.name)
+
+    def test_subset_name_propagation(self):
+        subset_name = 'foo_subset_name'
+        subset = dp.subset(self.subregion, self.target_dataset,subset_name)
+        self.assertEqual(subset.name, subset_name)
+
     def test_subset_using_non_exact_spatial_bounds(self):
         index_slices = dp._get_subregion_slice_indices(self.non_exact_spatial_subregion,  self.target_dataset)
         control_index_slices = {"lat_start"  : 5,


### PR DESCRIPTION
Made the naming of the subregion optional at it is not a necessity, but a nice feature to keep track of datasets.