### PR TITLE
CLIMATE-605 - Fix typo in plotter.draw_contour_map docstring

### DIFF
--- a/ocw/plotter.py
+++ b/ocw/plotter.py
@@ -494,7 +494,7 @@ def draw_contour_map(dataset, lats, lons, fname, fmt='png', gridshape=(1, 1),
                      extend='neither', aspect=8.5/2.5):
     ''' Draw a multiple panel contour map plot.
 
-    :param dataset: 3D array of data to be plotted with shape (nT, nLon, nLat).
+    :param dataset: 3D array of data to be plotted with shape (nT, nLat, nLon).
     :type dataset: :class:`numpy.ndarray`
 
     :param lats: Array of latitudes values.


### PR DESCRIPTION
- Update plotter.draw_contour_map docstring to specify proper expected
  data shape.