### PR TITLE
CLIMATE-608 - Add mailmap file to repo

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1,0 +1,28 @@
+Michael Joyce               <joyce@apache.org>          joyce                           <joyce@unknown>
+Michael Joyce               <joyce@apache.org>          mjjoyce                         <mjjoyce@unknown>
+Michael Joyce               <joyce@apache.org>                                          <mltjoyce@gmail.com>
+Cameron Eugene Goodale      <goodale@apache.org>        cgoodale                        <cgoodale@apache.org>
+Cameron Eugene Goodale      <goodale@apache.org>        cgoodale                        <cgoodale@unknown>
+Cameron Eugene Goodale      <goodale@apache.org>        Cameron Eugene Goodale          <cgoodale@apache.org>
+Cameron Eugene Goodale      <goodale@apache.org>        Cameron Eugene Goodale          <goodale@apache.org>
+Cameron Eugene Goodale      <goodale@apache.org>        cgoodale                        <sigep311@gmail.com>
+Cameron Eugene Goodale      <goodale@apache.org>        Cameron Goodale                 <goodale@apache.org>
+Shakeh Elisabeth Khudikyan  <skhudiky@apache.org>       skhudiky                        <skhudiky@unknown>
+Shakeh Elisabeth Khudikyan  <skhudiky@apache.org>       Shakeh                          <sekhudikyan@gmail.com>
+Maziyar Boustani            <boustani@apache.org>       Maziyar Boustani                <maziyar_b4@yahoo.com>
+Maziyar Boustani            <boustani@apache.org>       boustani                        <boustani@unknown>
+Lewis John McGibbney        <lewismc@apache.org>        Lewis John McGibbney            <lewis.j.mcgibbney@jpl.nasa.gov>
+Kim Whitehall               <whitehall@apache.org>      kwhitehall                      <k_whitehall@yahoo.com>
+Kim Whitehall               <whitehall@apache.org>      Kim Whitehall                   <k_whitehall@yahoo.com>
+Kim Whitehall               <whitehall@apache.org>      whitehall                       <whitehall@unknown>
+Kim Whitehall               <whitehall@apache.org>      Kim Whitehall                   <kwhitehall@users.noreply.github.com>
+Kim Whitehall               <whitehall@apache.org>      georgette                       <k_whitehall@yahoo.com>
+Huikyo Lee                  <huikyole@apache.org>       huikyole                        <huikyole@unknown>
+Ross Laidlaw                <rlaidlaw@apache.org>       rlaidlaw                        <rlaidlaw.open@gmail.com>
+Paul Michael Ramirez        <pramirez@apache.org>       Paul Ramirez
+Alex Goodman                <goodman@apache.org>        goodman                         <goodman@unknown>
+Alex Goodman                <goodman@apache.org>        bassdx                          <agoodman1120@gmail.com>
+Luca Cinquini               <luca@apache.org>           cinquini                        <cinquini@unknown>
+Denis Nadeau                <dnadeau@apache.org>        Denis Nadeau                    <dnadeau@esgcmor.gsfc.nasa.gov>
+Denis Nadeau                <dnadeau@apache.org>        dnadeau                         <dnadeau@unknown>
+Denis Nadeau                <dnadeau@apache.org>        Nadeau                          <dnadeau@GSSLA40018857.nccs.nasa.gov>


### PR DESCRIPTION
- Updated this slightly since my local copy that I've had sitting around was a bit out of date. Hopefully I didn't overlook anyone or misspell something. It looks like everything is mapping back to apache names/emails properly when tested locally.

```
| -> git shortlog -sne
   944  Michael Joyce <joyce@apache.org>
   204  Cameron Eugene Goodale <goodale@apache.org>
    57  Maziyar Boustani <boustani@apache.org>
    52  Andrew Hart <ahart@apache.org>
    39  Shakeh Elisabeth Khudikyan <skhudiky@apache.org>
    34  Kim Whitehall <whitehall@apache.org>
    22  Lewis John McGibbney <lewismc@apache.org>
    16  jwhittel <jwhittel@unknown>
    15  Huikyo Lee <huikyole@apache.org>
    14  Ross Laidlaw <rlaidlaw@apache.org>
    11  Alex Goodman <goodman@apache.org>
    11  Paul Michael Ramirez <pramirez@apache.org>
     7  Chris Mattmann <mattmann@apache.org>
     7  Denis Nadeau <dnadeau@apache.org>
     4  Luca Cinquini <luca@apache.org>
     3  Suresh Marru <smarru@apache.org>
     2  Joe Schaefer <joes@apache.org>
     1  Paul Zimdars <pzimdars@apache.org>
```