### PR TITLE
CLIMATE-609 - Add data source flag to dataset origin information

### DIFF
--- a/ocw/data_source/dap.py
+++ b/ocw/data_source/dap.py
@@ -59,7 +59,10 @@ def load(url, variable, name=''):
     lons = np.array(dataset[lon][:])
     values = np.array(dataset[:])
 
-    origin = {'url': url}
+    origin = {
+        'source': 'dap',
+        'url': url
+    }
 
     return Dataset(lats, lons, times, values, variable,
                    name=name, origin=origin)

--- a/ocw/data_source/esgf.py
+++ b/ocw/data_source/esgf.py
@@ -84,7 +84,11 @@ def load_dataset(dataset_id,
                                         name=name,
                                         elevation_index=elevation_index))
 
-    origin = {'dataset_id': dataset_id, 'variable': variable}
+    origin = {
+        'source': 'esgf',
+        'dataset_id': dataset_id,
+        'variable': variable
+    }
     for ds in datasets:
         ds.origin = origin
 

--- a/ocw/data_source/local.py
+++ b/ocw/data_source/local.py
@@ -212,6 +212,7 @@ def load_file(file_path,
             values = values [:,:,:,elevation_index]
 
     origin = {
+        'source': 'local',
         'path': file_path,
         'lat_name': lat_name,
         'lon_name': lon_name,

--- a/ocw/data_source/rcmed.py
+++ b/ocw/data_source/rcmed.py
@@ -357,6 +357,7 @@ def parameter_dataset(dataset_id, parameter_id, min_lat, max_lat, min_lon, max_l
     values = _make_mask_array(values, parameter_id, parameters_metadata)
 
     origin = {
+        'source': 'rcmed',
         'dataset_id': dataset_id,
         'parameter_id': parameter_id
     }

--- a/ocw/tests/test_dap.py
+++ b/ocw/tests/test_dap.py
@@ -47,6 +47,7 @@ class TestDap(unittest.TestCase):
         self.assertEquals(self.dataset.name, self.name)
 
     def test_dataset_origin(self):
+        self.assertEquals(self.dataset.origin['source'], 'dap')
         self.assertEquals(self.dataset.origin['url'], self.url)
 
 if __name__ == '__main__':

--- a/ocw/tests/test_local.py
+++ b/ocw/tests/test_local.py
@@ -71,9 +71,10 @@ class test_load_file(unittest.TestCase):
 
     def test_dataset_origin(self):
         ds = local.load_file(self.file_path, 'value', elevation_index=1)
-        expected_keys = set(['path', 'lat_name', 'lon_name',
-                         'time_name', 'elevation_index' ])
+        expected_keys = set(['source', 'path', 'lat_name', 'lon_name',
+                             'time_name', 'elevation_index' ])
         self.assertEqual(set(ds.origin.keys()), expected_keys)
+        self.assertEqual(ds.origin['source'], 'local')
 
 
 class test_get_netcdf_variable_names(unittest.TestCase):

--- a/ocw/tests/test_rcmed.py
+++ b/ocw/tests/test_rcmed.py
@@ -119,6 +119,8 @@ class test_rcmed(unittest.TestCase, CustomAssertions):
                                      self.start_time,
                                      self.end_time,
                                      name='foo')
+
+        self.assertEquals(ds.origin['source'], 'rcmed')
         self.assertEquals(ds.origin['dataset_id'], self.dataset_id)
         self.assertEquals(ds.origin['parameter_id'], self.parameter_id)
 


### PR DESCRIPTION
- Add a 'source' flag to dataset origin information when loaded from a
  data_source. This is set to 'local', 'dap', 'esgf', or 'rcmed'
  depending on the data_source used.
- Update data_source tests to take new source flag into account.