### PR TITLE
CLIMATE-619 - Default ocw_path to user HOME dir

### DIFF
--- a/easy-ocw/install-ubuntu.sh
+++ b/easy-ocw/install-ubuntu.sh
@@ -63,6 +63,7 @@ echo
 WITH_VIRTUAL_ENV=0
 WITH_HOMEBREW=0
 WITH_INTERACT=1
+ocw_path="${HOME}/climate"
 
 while getopts ":h :e :q" FLAG
 do


### PR DESCRIPTION
Set the default ocw_path directory to the user's HOME directory so that running in quiet mode doesn't cause empty paths to be inserted into the user's RC file. This isn't foolproof but covers the VM build and the general use case that arises from reading the various guides on the Wiki.