### PR TITLE
CLIMATE-622 - allow Bounds object to take optional start and end times

### DIFF
--- a/ocw/dataset.py
+++ b/ocw/dataset.py
@@ -236,7 +236,7 @@ class Bounds(object):
     * Temporal bounds must a valid datetime object
     '''
 
-    def __init__(self, lat_min, lat_max, lon_min, lon_max, start, end):
+    def __init__(self, lat_min, lat_max, lon_min, lon_max, start=None, end=None):
         '''Default Bounds constructor
 
         :param lat_min: The minimum latitude bound.
@@ -251,10 +251,10 @@ class Bounds(object):
         :param lon_max: The maximum longitude bound.
         :type lon_max: :class:`float`
 
-        :param start: The starting datetime bound.
+        :param start: An optional datetime object for the starting datetime bound.
         :type start: :class:`datetime.datetime`
 
-        :param end: The ending datetime bound.
+        :param end: An optional datetime object for the ending datetime bound.
         :type end: :class:`datetime.datetime`
 
         :raises: ValueError
@@ -263,8 +263,16 @@ class Bounds(object):
         self._lat_max = float(lat_max)
         self._lon_min = float(lon_min)
         self._lon_max = float(lon_max)
-        self._start = start
-        self._end = end
+
+        if not start:
+            self._start = None 
+        else:
+            self._start = start
+
+        if not end:
+            self._end = None 
+        else:
+            self._end = end
 
     @property
     def lat_min(self):
@@ -324,10 +332,11 @@ class Bounds(object):
 
     @start.setter
     def start(self, value):
-        if not (type(value) is dt.datetime and value < self._end):
-            error = "Attempted to set start to invalid value: %s" % (value)
-            logger.error(error)
-            raise ValueError(error)
+        if self._end:
+            if not (type(value) is dt.datetime and value < self._end):
+                error = "Attempted to set start to invalid value: %s" % (value)
+                logger.error(error)
+                raise ValueError(error)
 
         self._start = value
 
@@ -337,10 +346,11 @@ class Bounds(object):
 
     @end.setter
     def end(self, value):
-        if not (type(value) is dt.datetime and value > self._start):
-            error = "Attempted to set end to invalid value: %s" % (value)
-            logger.error(error)
-            raise ValueError(error)
+        if self._start:
+            if not (type(value) is dt.datetime and value > self._start):
+                error = "Attempted to set end to invalid value: %s" % (value)
+                logger.error(error)
+                raise ValueError(error)
 
         self._end = value
 

--- a/ocw/dataset_processor.py
+++ b/ocw/dataset_processor.py
@@ -169,7 +169,11 @@ def subset(subregion, target_dataset, subregion_name=None):
 
     :raises: ValueError
     '''
-
+    
+    if not subregion.start:
+        subregion.start = target_dataset.times[0] 
+        subregion.end = target_dataset.times[-1]
+        
     # Ensure that the subregion information is well formed
     _are_bounds_contained_by_dataset(subregion, target_dataset)
 

--- a/ocw/dataset_processor.py
+++ b/ocw/dataset_processor.py
@@ -169,7 +169,7 @@ def subset(subregion, target_dataset, subregion_name=None):
 
     :raises: ValueError
     '''
-    
+
     if not subregion.start:
         subregion.start = target_dataset.times[0] 
         subregion.end = target_dataset.times[-1]
@@ -240,11 +240,13 @@ def safe_subset(subregion, target_dataset, subregion_name=None):
     if subregion.lon_max > lon_max:
         subregion.lon_max = lon_max
 
-    if subregion.start < start:
-        subregion.start = start
+    if subregion.start: 
+        if subregion.start < start:
+            subregion.start = start
 
-    if subregion.end > end:
-        subregion.end = end
+    if subregion.end:
+        if subregion.end > end:
+            subregion.end = end
 
     return subset(subregion, target_dataset, subregion_name)
 


### PR DESCRIPTION
- Update the start and end parameter in the Bounds class in DS to optional parameters
- Update the subset and safe_subset functions in DSP to set the time ranges to that of the target DS      when subsetting if no Bounds time-ranges are entered. 