### PR TITLE
CLIMATE-639 - Add subregion support to config runner

### DIFF
--- a/ocw-config-runner/configuration_parsing.py
+++ b/ocw-config-runner/configuration_parsing.py
@@ -117,6 +117,11 @@ def _config_is_well_formed(config_data):
             if not _valid_plot_config_data(plot):
                 is_well_formed = False
 
+    if 'subregions' in config_data:
+        for subregion in config_data['subregions']:
+            if not _valid_subregion_config_data(subregion):
+                is_well_formed = False
+
     return is_well_formed
 
 def _contains_unary_metrics(config_metric_data):
@@ -233,3 +238,22 @@ def _valid_plot_config_data(plot_config_data):
 
     return True
 
+def _valid_subregion_config_data(subregion_config_data):
+    """"""
+    if type(subregion_config_data) != type([]):
+        logger.error(
+            'Subregions should be passed as a list of lists where '
+            'each sub-list contains a bounding box of the form: '
+            '[lat_min, lat_max, lon_min, lon_max].'
+        )
+        return False
+
+    if len(subregion_config_data) != 4:
+        logger.error(
+            'Subregions should be passed as a list of lists where '
+            'each sub-list contains a bounding box of the form: '
+            '[lat_min, lat_max, lon_min, lon_max].'
+        )
+        return False
+
+    return True

--- a/ocw-config-runner/configuration_writer.py
+++ b/ocw-config-runner/configuration_writer.py
@@ -37,6 +37,7 @@ def export_evaluation_to_config(evaluation, file_path='./exported_eval.yaml'):
     config['evaluation'] = generate_evaluation_information(evaluation)
     config['datasets'] = generate_dataset_information(evaluation)
     config['metrics'] = generate_metric_information(evaluation)
+    config['subregions'] = generate_subregion_information(evaluation)
 
     yaml.dump(config, file(file_path, 'w'))
 
@@ -157,6 +158,22 @@ def generate_evaluation_information(evaluation):
         eval_config['subset'] = _calc_subset_config(datasets)
 
     return eval_config
+
+def generate_subregion_information(evaluation):
+    ''' Generate subregion config file output from a given Evaluation object.
+
+    :param evaluation: The evaluation object from which to extract metrics.
+    :type evaluation: :class:`evaluation.Evaluation`
+
+    :returns: A :func:`list` of :func:`list` objects containing bounding
+        box info for export into a configuration file
+    :rtype: :func:`list` of :func:`list`
+    '''
+    subregions = []
+    for s in evaluation.subregions:
+        subregions.append([s.lat_min, s.lat_max, s.lon_min, s.lon_max])
+
+    return subregions
 
 def _extract_local_dataset_info(dataset):
     ''''''

--- a/ocw-config-runner/evaluation_creation.py
+++ b/ocw-config-runner/evaluation_creation.py
@@ -58,7 +58,12 @@ def generate_evaluation_from_config(config_data):
     # Load metrics
     eval_metrics = [_load_metric(m)() for m in config_data['metrics']]
 
-    return Evaluation(reference, targets, eval_metrics)
+    # Load Subregions (if present)
+    subregions = None
+    if 'subregions' in config_data:
+        subregions = [_load_subregion(s) for s in config_data['subregions']]
+
+    return Evaluation(reference, targets, eval_metrics, subregions=subregions)
 
 def _load_dataset(dataset_config_data):
     """"""
@@ -147,3 +152,10 @@ def _load_metric(metric_config_data):
         return None
 
     return getattr(metrics, metric_config_data)
+
+def _load_subregion(subregion_config_data):
+    """"""
+    return Bounds(float(subregion_config_data[0]),
+                  float(subregion_config_data[1]),
+                  float(subregion_config_data[2]),
+                  float(subregion_config_data[3]))

--- a/ocw-config-runner/tests/test_config_parsing.py
+++ b/ocw-config-runner/tests/test_config_parsing.py
@@ -290,6 +290,36 @@ class TestConfigIsWellFormed(unittest.TestCase):
         """
         bad_plot = yaml.load(bad_plot_config)
 
+        bad_subregion_config_type = """
+            datasets:
+                reference:
+                    data_source: dap
+                    url: afakeurl.com
+                    variable: pr
+
+            metrics:
+                - Bias
+
+            subregions:
+                - this is a string instead of a list
+        """
+        self.bad_subregion_type = yaml.load(bad_subregion_config_type)
+
+        bad_subregion_config_length = """
+            datasets:
+                reference:
+                    data_source: dap
+                    url: afakeurl.com
+                    variable: pr
+
+            metrics:
+                - Bias
+
+            subregions:
+                - [1, 2, 3, 4, 5]
+        """
+        self.bad_subregion_length = yaml.load(bad_subregion_config_length)
+
     def test_malformed_reference_config(self):
         ret = parser._config_is_well_formed(self.malformed_reference_conf)
         self.assertFalse(ret)
@@ -319,6 +349,14 @@ class TestConfigIsWellFormed(unittest.TestCase):
 
     def test_bad_plot_config(self):
         ret = parser._config_is_well_formed(self.missing_metric_name)
+        self.assertFalse(ret)
+    
+    def test_bad_subregion_type(self):
+        ret = parser._config_is_well_formed(self.bad_subregion_type)
+        self.assertFalse(ret)
+
+    def test_bad_subregion_length(self):
+        ret = parser._config_is_well_formed(self.bad_subregion_length)
         self.assertFalse(ret)
 
 


### PR DESCRIPTION
Note, at the moment this does not include changes necessary to support subregions in the plot handling. That will be coming along shortly.