### PR TITLE
CLIMATE-650 - Fix the ensemble calculation

### DIFF
--- a/ocw/dataset_processor.py
+++ b/ocw/dataset_processor.py
@@ -186,7 +186,7 @@ def ensemble(datasets):
     """
     _check_dataset_shapes(datasets)
     dataset_values = [dataset.values for dataset in datasets]
-    ensemble_values = np.mean(dataset_values, axis=0)
+    ensemble_values = ma.mean(dataset_values, axis=0)
     
     # Build new dataset object from the input datasets and the ensemble values and return it
     ensemble_dataset = ds.Dataset(datasets[0].lats, 


### PR DESCRIPTION
- Fix: ocw.dataset_processor.ensemble now uses numpy.ma.mean instead of numpy.mean to properly handle missing values.