### PR TITLE
CLIMATE-667 - OCW spatial_boundaries bug

### DIFF
--- a/ocw/dataset.py
+++ b/ocw/dataset.py
@@ -89,8 +89,8 @@ class Dataset:
             :class:`float`, :class:`float`).
 
         '''
-        return (float(min(self.lats)), float(max(self.lats)),
-                float(min(self.lons)), float(max(self.lons)))
+        return (float(numpy.min(self.lats)), float(numpy.max(self.lats)),
+                float(numpy.min(self.lons)), float(numpy.max(self.lons)))
 
 
     def time_range(self):


### PR DESCRIPTION
- ocw.dataset.spatial_boundaries uses np.min and np.max instead of min and max