### PR TITLE
CLIMATE-669 - OCW spatial_boundary bug

### DIFF
--- a/ocw/dataset.py
+++ b/ocw/dataset.py
@@ -89,8 +89,8 @@ class Dataset:
             :class:`float`, :class:`float`).
 
         '''
-        return (float(min(self.lats)), float(max(self.lats)),
-                float(min(self.lons)), float(max(self.lons)))
+        return (float(numpy.min(self.lats)), float(numpy.max(self.lats)),
+                float(numpy.min(self.lons)), float(numpy.max(self.lons)))
 
 
     def time_range(self):


### PR DESCRIPTION
- min and max functions in ocw.dataset.spatial_boundaries are replaced by numpy.min and numpy.max