### PR TITLE
CLIMATE-711 - Resolve bashrc sourcing issue in conda-install

### DIFF
--- a/easy-ocw/conda-install.sh
+++ b/easy-ocw/conda-install.sh
@@ -36,9 +36,10 @@ command -v conda >/dev/null 2>&1 || {
         echo "Unable to identify your OS. Please report this to the OCW List"
         echo "dev@climate.apache.org"
     fi
-
-    source ~/.bashrc
 }
+
+PS1='$ '
+source ~/.bashrc
 
 echo "Creating conda environment from ocw environment file"
 conda env create -f conda_environment.txt


### PR DESCRIPTION
- The conda-install.sh Easy-OCW script now sets PS1 prior to attempting
  to source bashrc to ensure that conda is locatable after install.
- The post-miniconda bashrc source has been moved out the miniconda
  install block.