### PR TITLE
CLIMATE-691 - Add a link to the RCMED Query Specification.

### DIFF
--- a/ocw/data_source/rcmed.py
+++ b/ocw/data_source/rcmed.py
@@ -18,6 +18,8 @@
 '''
 Classes:
     RCMED - A class for retrieving data from Regional Climate Model Evalutaion Database (JPL).
+    More information about the RCMED Query Specification can be found below:
+    https://rcmes.jpl.nasa.gov/query-api/query.php?
 '''
 
 import urllib, urllib2


### PR DESCRIPTION
A reference to the RCMED Query Specification was already being used by the URL variable.

I was between adding the link to the "get_parameters_metadata()" method documentation or adding it to the Class documentation. I ended up going with the second option.

Let me know if you think this should go somewhere else and/or if the wording could be improved.