### PR TITLE
CLIMATE-738 - Update  Google jsapi call to use https rather than http.

### DIFF
--- a/ocw-ui/frontend/app/index.html
+++ b/ocw-ui/frontend/app/index.html
@@ -93,7 +93,7 @@ under the License.
     <!-- Google visualization library needs to be initialized for the timeline -->
     <!-- Note that the terms of use forbid having a local copy of the code, so we're -->
     <!-- stuck downloading it this way unfortunately. -->
-    <script type="text/javascript" src="http://www.google.com/jsapi"></script>
+    <script type="text/javascript" src="https://www.google.com/jsapi"></script>
     <script type="text/javascript">google.load("visualization", "1");</script>
 
     <!-- build:js(.) scripts/vendor.js -->
@@ -150,14 +150,14 @@ under the License.
       <div class="container">
         <hr>
         <p>
-          Apache Open Climate Workbench Software . 
+          Apache Open Climate Workbench Software .
           <a href="https://climate.apache.org/" target="_blank">About Us</a> . <a href="dev@climate.apache.org" target="_blank">Report an issue</a> .
           <br>
-          Copyright © 2013 The Apache Software Foundation, Licensed under the 
+          Copyright © 2013 The Apache Software Foundation, Licensed under the
           <a href="http://www.apache.org/licenses/LICENSE-2.0">Apache License, Version 2.0</a>.
         </p>
       </div>
     <footer>
-      
+
   </body>
 </html>


### PR DESCRIPTION
Updated index.html to use https rather than http when loading Google jsapi.

https://developers.google.com/loader/?hl=en

Fixes page not found / object not set when loading page.