### PR TITLE
CLIMATE-752 - Converting the unit of CRU cloud fraction by adding an option to configuration files

### DIFF
--- a/RCMES/configuration_files/CORDEX-Africa_examples/Fig10a_cru.yaml
+++ b/RCMES/configuration_files/CORDEX-Africa_examples/Fig10a_cru.yaml
@@ -29,6 +29,7 @@ datasets:
         data_name: CRU  
         dataset_id: 10
         parameter_id: 42
+        multiplying_factor: 0.01
 
     targets:
         data_source: local

--- a/RCMES/configuration_files/CORDEX-Africa_examples/Fig4f_9bcd.yaml
+++ b/RCMES/configuration_files/CORDEX-Africa_examples/Fig4f_9bcd.yaml
@@ -29,6 +29,7 @@ datasets:
         data_name: CRU  
         dataset_id: 10
         parameter_id: 42
+        multiplying_factor: 0.01
 
     targets:
         data_source: local


### PR DESCRIPTION
- Unit of CRU's cloud fraction data in RCMED (dataset_id: 10, parameter_id:42) is %, whereas all of CORDEX Africa RCMs have dimensionless cloud fraction. 'multiplying_factor' option will match the unit between the observation and models.