### PR TITLE
CLIMATE-766 Easy-ocw/install-ubuntu.sh script is broken

### DIFF
--- a/easy-ocw/install-ubuntu.sh
+++ b/easy-ocw/install-ubuntu.sh
@@ -148,24 +148,9 @@ if [ $WITH_VIRTUAL_ENV == 1 ]; then
     subtask "done"
 fi
 
-# Install Continuum Analytics Anaconda Python distribution. This gives
-# almost all the dependencies that OCW needs in a single, easy to
-# install package.
-
-header "Installing Anaconda Python distribution ..."
-echo
-echo "*** NOTE *** When asked to update your PATH, you should respond YES."
-read -p "Press [ENTER] to continue ..."
-
-cd
-task "Downloading Anaconda ..."
-wget -O Anaconda-1.9.2-Linux-x86_64.sh "http://repo.continuum.io/archive/Anaconda-1.9.2-Linux-x86_64.sh" 2>> install_log
-subtask "done"
-
-task "Installing ..."
-bash Anaconda-1.9.2-Linux-x86_64.sh
-export PATH="${HOME}/anaconda/bin:$PATH"
-subtask "done"
+# Install miscellaneous Python packages with Pip.
+header "Installing additional Python packages"
+pip install -r ocw-pip-dependencies.txt >> install_log
 
 # Install Basemap. Conda cannot be used for this install since
 # it fails to analyse the dependencies (at the time of writing). This
@@ -196,11 +181,8 @@ subtask "done"
 
 cd
 
-# Install miscellaneous Python packages needed for OCW. Some of these
-# can be installed with Conda, but since none of them have an annoying
-# compiled component we just installed them with Pip.
-header "Installing additional Python packages"
-pip install -r ocw-pip-dependencies.txt >> install_log
+# Install OCW itself
+cd ${ocw_path}/.. && python setup.py install
 
 # Ensure that the climate code is included in the Python Path
 header "Updating PYTHONPATH with ocw executables ..."

--- a/easy-ocw/install-ubuntu.sh
+++ b/easy-ocw/install-ubuntu.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+
 #
 # Licensed to the Apache Software Foundation (ASF) under one
 # or more contributor license agreements.  See the NOTICE file
@@ -119,9 +119,11 @@ case $yn in
     * ) echo "Please answer yes or no.." ;;
 esac
 
-echo -n "Please specify a full path to where your OCW download is then press [ENTER] ..."
-read ocw_path
 fi
+
+# Find absolute path to the easy-ocw directory
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+cd $DIR
 
 header "Checking for pip ..."
 command -v pip >/dev/null 2>&1 || { 
@@ -143,48 +145,47 @@ if [ $WITH_VIRTUAL_ENV == 1 ]; then
 
     # Create a new environment for OCW work
     task "Creating a new environment ..."
-    virtualenv ocw >> install_log
-    source ocw/bin/activate
+    virtualenv venv-ocw >> install_log
+    source venv-ocw/bin/activate
     subtask "done"
 fi
 
-# Install miscellaneous Python packages with Pip.
+# Install Continuum Analytics Miniconda Python distribution. This gives
+# almost all the dependencies that OCW needs in a single, easy to
+# install package.
+
+header "Installing Miniconda Python distribution ..."
+echo
+echo "*** NOTE *** When asked to update your PATH, you should respond YES and please do not change the default installation directory"
+read -p "Press [ENTER] to continue ..."
+
+
+task "Downloading Miniconda ..."
+wget -O Miniconda-latest-linux.sh "https://repo.continuum.io/miniconda/Miniconda-latest-Linux-x86_64.sh" 2>> install_log
+subtask "done"
+
+task "Installing ..."
+bash Miniconda-latest-linux.sh
+subtask "done"
+
+header "Installing dependencies via conda"
+task "Reading and installing from ocw-conda-dependencies.txt"
+conda install --file ocw-conda-dependencies.txt >> install_log
+subtask "done"
+
+# Install miscellaneous Python packages needed for OCW. Some of these
+# can be installed with Conda, but since none of them have an annoying
+# compiled component we just installed them with Pip.
 header "Installing additional Python packages"
+task "Reading and installing from ocw-pip-dependencies.txt"
 pip install -r ocw-pip-dependencies.txt >> install_log
-
-# Install Basemap. Conda cannot be used for this install since
-# it fails to analyse the dependencies (at the time of writing). This
-# will install it manually. At some point, this should be replaced with
-# 'conda install basemap' once it is working again!
-header "Handling Basemap install ..."
-
-cd
-task "Downloading basemap ..."
-wget -O basemap-1.0.7.tar.gz "http://sourceforge.net/projects/matplotlib/files/matplotlib-toolkits/basemap-1.0.7/basemap-1.0.7.tar.gz/download" 2>> install_log
-tar xzf basemap-1.0.7.tar.gz >> install_log
 subtask "done"
 
-# Install GEOS
-task "Installing GEOS dependency ..."
-cd basemap-1.0.7/geos-3.3.3
-export GEOS_DIR=/usr/local
-./configure --prefix=$GEOS_DIR >> install_log
-sudo make >> install_log
-sudo make install >> install_log
-subtask "done"
-
-# Install basemap
-task "Installing Basemap ..."
+header "Installing ocw module"
 cd ..
 python setup.py install >> install_log
-subtask "done"
+subtask "finished installing ocw module"
 
-cd
+header "Installation completed. Please close the terminal and start to new one for the changes to take effect"
+header "For any issues with installation please contact dev@climate.apache.org"
 
-# Install OCW itself
-cd ${ocw_path}/.. && python setup.py install
-
-# Ensure that the climate code is included in the Python Path
-header "Updating PYTHONPATH with ocw executables ..."
-echo "export PYTHONPATH=${ocw_path}:${ocw_path}/ocw" >> ${HOME}/.bashrc
-subtask "done"

--- a/easy-ocw/ocw-conda-dependencies.txt
+++ b/easy-ocw/ocw-conda-dependencies.txt
@@ -15,9 +15,9 @@
 # specific language governing permissions and limitations
 # under the License.
 
-numpy=1.8.1
-scipy=0.13.3
-matplotlib=1.3.1
-basemap=1.0.7
-netcdf4=1.0.8
-h5py=2.5.0
+numpy
+scipy
+matplotlib
+basemap
+netcdf4
+h5py

--- a/easy-ocw/ocw-pip-dependencies.txt
+++ b/easy-ocw/ocw-pip-dependencies.txt
@@ -1,3 +1,5 @@
+numpy==1.10.4
+matplotlib==1.5.1
 requests==2.3.0
 bottle==0.11.6
 pydap==3.1.1

--- a/easy-ocw/ocw-pip-dependencies.txt
+++ b/easy-ocw/ocw-pip-dependencies.txt
@@ -1,13 +1,28 @@
-numpy==1.10.4
-matplotlib==1.5.1
-requests==2.3.0
-bottle==0.11.6
-pydap==3.1.1
-webtest==2.0.15
-nose==1.3.3
-nose-exclude==0.2.0
-pylint==1.2.1
-sphinx==1.2.1
-sphinxcontrib-httpdomain==1.2.1
-esgf-pyclient==0.1.2
-python-dateutil==2.4.1
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+requests
+bottle
+pydap
+webtest
+nose
+nose-exclude
+pylint
+sphinx
+sphinxcontrib-httpdomain
+esgf-pyclient
+python-dateutil


### PR DESCRIPTION
This initial pull request addresses the following issues from https://issues.apache.org/jira/browse/CLIMATE-766

 1. Missing dependencies: Even after running the script there are multiple missing dependency errors. The script also does not install 'numpy' which is required.
 3. The script does not install the climate module (by executing 'python setup.py install')

Still to be addressed

 2. Multiple install_logs : The script create log file in whichever directory it is in. 
 4. The script does not install dependencies via anaconda. That means modules 'h5py', 'netcdf4', etc are not installed which are required.

