### PR TITLE
fix issue CLIMATE-759

### DIFF
--- a/ocw/dataset_processor.py
+++ b/ocw/dataset_processor.py
@@ -903,7 +903,7 @@ def _rcmes_calc_average_on_new_time_unit(data, dates, unit):
     acceptable = (unit=='full')|(unit=='annual')|(unit=='monthly')|(unit=='daily')
     if not acceptable:
         print 'Error: unknown unit type selected for time averaging: EXIT'
-        return -1,-1,-1,-1
+        return -1,-1
 
     nt, ny, nx = data.shape
     if unit == 'full':
@@ -968,7 +968,7 @@ def _rcmes_calc_average_on_new_time_unit_K(data, dates, unit):
     acceptable = (unit=='full')|(unit=='annual')|(unit=='monthly')|(unit=='daily')
     if not acceptable:
         print 'Error: unknown unit type selected for time averaging: EXIT'
-        return -1,-1,-1,-1
+        return -1,-1
 
     # Calculate arrays of: annual timeseries: year (2007,2007),
     #                      monthly time series: year-month (200701,200702),

--- a/ocw/tests/test_dataset_processor.py
+++ b/ocw/tests/test_dataset_processor.py
@@ -65,24 +65,24 @@ class TestTemporalRebin(unittest.TestCase):
         self.two_years_daily_dataset = two_year_daily_dataset()
     
     def test_monthly_to_annual_rebin(self):
-        annual_dataset = dp.temporal_rebin(self.ten_year_monthly_dataset, datetime.timedelta(days=365))
+        annual_dataset = dp.temporal_rebin(self.ten_year_monthly_dataset, 'annual')
         np.testing.assert_array_equal(annual_dataset.times, self.ten_year_annual_times)
     
     def test_monthly_to_full_rebin(self):
-        full_dataset = dp.temporal_rebin(self.ten_year_monthly_dataset, datetime.timedelta(days=3650))
+        full_dataset = dp.temporal_rebin(self.ten_year_monthly_dataset, 'full')
         full_times = [datetime.datetime(2004, 12, 16)]
         self.assertEqual(full_dataset.times, full_times)
     
     def test_daily_to_monthly_rebin(self):
         """This test takes a really long time to run.  TODO: Figure out where the performance drag is"""
-        monthly_dataset = dp.temporal_rebin(self.two_years_daily_dataset, datetime.timedelta(days=31))
+        monthly_dataset = dp.temporal_rebin(self.two_years_daily_dataset, 'monthly')
         bins = list(set([datetime.datetime(time_reading.year, time_reading.month, 1) for time_reading in self.two_years_daily_dataset.times]))
         bins = np.array(bins)
         bins.sort()
         np.testing.assert_array_equal(monthly_dataset.times, bins)
     
     def test_daily_to_annual_rebin(self):
-        annual_dataset = dp.temporal_rebin(self.two_years_daily_dataset, datetime.timedelta(days=366))
+        annual_dataset = dp.temporal_rebin(self.two_years_daily_dataset, 'annual')
         bins = list(set([datetime.datetime(time_reading.year, 1, 1) for time_reading in self.two_years_daily_dataset.times]))
         bins = np.array(bins)
         bins.sort()
@@ -97,7 +97,7 @@ class TestTemporalRebin(unittest.TestCase):
 
     def test_variable_propagation(self):
         annual_dataset = dp.temporal_rebin(self.ten_year_monthly_dataset,
-                                           datetime.timedelta(days=365))
+                                           'annual')
         self.assertEquals(annual_dataset.name,
                           self.ten_year_monthly_dataset.name)
         self.assertEquals(annual_dataset.variable,


### PR DESCRIPTION
The `_rcmes_calc_average_on_new_time_unit_K(data, dates, unit)` function in `dataset_processor.py` required the `unit` to be `full` or `annual` or `monthly` or `daily`. The tests were failing due to the values returned by the function. On error it returned `-1, -1, -1, -1` when it should return `-1, -1` 