### PR TITLE
CLIMATE-768 - Fix failing tests in test_dap.py.  Add extra logic to dap.py to check for named dimensions. 

### DIFF
--- a/ocw/data_source/dap.py
+++ b/ocw/data_source/dap.py
@@ -17,9 +17,9 @@
 
 from pydap.client import open_url
 from netcdftime import utime
-import requests
 import numpy as np
 from ocw.dataset import Dataset
+
 
 def load(url, variable, name=''):
     '''Load a Dataset from an OpenDAP URL
@@ -42,16 +42,21 @@ def load(url, variable, name=''):
     d = open_url(url)
     dataset = d[variable]
 
-    # Grab the lat, lon, and time variable names.
-    # We assume the variable order is (time, lat, lon)
+    # By convention, but not by standard, if the dimensions exist, they will be in the order:
+    # time (t), altitude (z), latitude (y), longitude (x)
+    # but conventions aren't always followed and all dimensions aren't always present so
+    # see if we can make some educated deductions before defaulting to just pulling the first three
+    # columns.
+    temp_dimensions = map(lambda x:x.lower(),dataset.dimensions)
+
     dataset_dimensions = dataset.dimensions
-    time = dataset_dimensions[0]
-    lat = dataset_dimensions[1]
-    lon = dataset_dimensions[2]
+    time = dataset_dimensions[temp_dimensions.index('time') if 'time' in temp_dimensions else 0]
+    lat = dataset_dimensions[temp_dimensions.index('lat') if 'lat' in temp_dimensions else 1]
+    lon = dataset_dimensions[temp_dimensions.index('lon') if 'lon' in temp_dimensions else 2]
 
     # Time is given to us in some units since an epoch. We need to convert
     # these values to datetime objects. Note that we use the main object's
-    # time object and not the dataset specific reference to it. We need to 
+    # time object and not the dataset specific reference to it. We need to
     # grab the 'units' from it and it fails on the dataset specific object.
     times = np.array(_convert_times_to_datetime(d[time]))
 
@@ -66,6 +71,7 @@ def load(url, variable, name=''):
 
     return Dataset(lats, lons, times, values, variable,
                    name=name, origin=origin)
+
 
 def _convert_times_to_datetime(time):
     '''Convert the OpenDAP time object's values to datetime objects

--- a/ocw/tests/test_dap.py
+++ b/ocw/tests/test_dap.py
@@ -16,31 +16,33 @@
 # under the License.
 
 import unittest
+import datetime as dt
 import ocw.data_source.dap as dap
 from ocw.dataset import Dataset
-import datetime as dt
+
 
 class TestDap(unittest.TestCase):
     @classmethod
-    def setup_class(self):
-        self.url = 'http://test.opendap.org/opendap/data/ncml/agg/dated/CG2006158_120000h_usfc.nc'
-        self.name = 'foo'
-        self.dataset = dap.load(self.url, 'CGusfc', name=self.name)
+    def setUpClass(cls):
+
+        cls.url = 'http://test.opendap.org/opendap/data/ncml/agg/dated/CG2006158_120000h_usfc.nc'
+        cls.name = 'foo'
+        cls.dataset = dap.load(cls.url, 'CGusfc', name=cls.name)
 
     def test_dataset_is_returned(self):
         self.assertTrue(isinstance(self.dataset, Dataset))
 
     def test_correct_lat_shape(self):
-        self.assertEquals(len(self.dataset.lats), 89)
+        self.assertEquals(len(self.dataset.lats), 29)
 
     def test_correct_lon_shape(self):
-        self.assertEquals(len(self.dataset.lons), 180)
+        self.assertEquals(len(self.dataset.lons), 26)
 
     def test_correct_time_shape(self):
-        self.assertEquals(len(self.dataset.times), 1857)
+        self.assertEquals(len(self.dataset.times), 1)
 
     def test_valid_date_conversion(self):
-        start = dt.datetime(1854, 1, 1)
+        start = dt.datetime(2006, 6, 7, 12)
         self.assertTrue(start == self.dataset.times[0])
 
     def test_custom_dataset_name(self):


### PR DESCRIPTION
1.  Fix various Pylint complaints on dap.py and test_dap.py.
2.  Add extra logic to dap.py to inspect the dimensions list rather than just assuming time / lat / lon are the first three dimensions.
3.  Update the test cases to reflect the values found in the new test file added in CLIMATE-757.
4.  Update the name of the set up function in test_dap.py to ensure set up is called before executing tests.
