### PR TITLE
CLIMATE-572 Address deprecation and WARN's in ocw-ui/frontend npm ins…

### DIFF
--- a/ocw-ui/frontend/package.json
+++ b/ocw-ui/frontend/package.json
@@ -30,7 +30,7 @@
     "grunt-google-cdn": "^0.4.0",
     "grunt-karma": "^0.8.3",
     "grunt-newer": "^0.7.0",
-    "grunt-ngmin": "^0.0.3",
+    "grunt-ng-annotate": "^0.1.0",
     "grunt-svgmin": "^0.4.0",
     "grunt-usemin": "^2.1.1",
     "grunt-wiredep": "^1.8.0",


### PR DESCRIPTION
…tall

This pull requests adds a new package 'grunt-ng-annotate'  instead of 'grunt-ngmin' which is deprecated. ng-annotate has ngmin in its uspstream dependencies. Please take a look at it and let me if there are any issues. 

Thanks.