### PR TITLE
CLIMATE-792 - Fix PEP8 violations in tests

### DIFF
--- a/ocw/tests/test_dap.py
+++ b/ocw/tests/test_dap.py
@@ -25,7 +25,8 @@ class TestDap(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
 
-        cls.url = 'http://test.opendap.org/opendap/data/ncml/agg/dated/CG2006158_120000h_usfc.nc'
+        cls.url = 'http://test.opendap.org/opendap/data/ncml/agg/dated/'\
+                  'CG2006158_120000h_usfc.nc'
         cls.name = 'foo'
         cls.dataset = dap.load(cls.url, 'CGusfc', name=cls.name)
 

--- a/ocw/tests/test_dataset.py
+++ b/ocw/tests/test_dataset.py
@@ -22,6 +22,7 @@ from ocw.dataset import Dataset, Bounds
 import numpy as np
 import datetime as dt
 
+
 class TestDatasetAttributes(unittest.TestCase):
     def setUp(self):
         self.lat = np.array([10, 12, 14, 16, 18])
@@ -61,6 +62,7 @@ class TestDatasetAttributes(unittest.TestCase):
     def test_origin(self):
         self.assertEqual(self.test_dataset.origin, self.origin)
 
+
 class TestInvalidDatasetInit(unittest.TestCase):
     def setUp(self):
         self.lat = np.array([10, 12, 14, 16, 18])
@@ -96,9 +98,9 @@ class TestInvalidDatasetInit(unittest.TestCase):
         self.lat = self.lat[:-2]
         with self.assertRaises(ValueError):
             Dataset(self.lat, self.lon, self.time, self.value, 'prec')
-    
+
     def test_values_given_in_wrong_order(self):
-         with self.assertRaises(ValueError):
+        with self.assertRaises(ValueError):
             Dataset(self.lat, self.lon, self.time, self.values_in_wrong_order)
 
     def test_lons_values_incorrectly_gridded(self):
@@ -110,10 +112,11 @@ class TestInvalidDatasetInit(unittest.TestCase):
 
         ds = Dataset(lats, bad_lons, times, values)
         np.testing.assert_array_equal(ds.lons, np.arange(-180, 180))
-    
+
     def test_reversed_lats(self):
         ds = Dataset(self.lat[::-1], self.lon, self.time, self.value)
         np.testing.assert_array_equal(ds.lats, self.lat)
+
 
 class TestDatasetFunctions(unittest.TestCase):
     def setUp(self):
@@ -123,17 +126,17 @@ class TestDatasetFunctions(unittest.TestCase):
         flat_array = np.array(range(300))
         self.value = flat_array.reshape(12, 5, 5)
         self.variable = 'prec'
-        self.test_dataset = Dataset(self.lat, self.lon, self.time, 
-                                     self.value, self.variable)
+        self.test_dataset = Dataset(self.lat, self.lon, self.time,
+                                    self.value, self.variable)
 
     def test_spatial_boundaries(self):
         self.assertEqual(
-            self.test_dataset.spatial_boundaries(), 
+            self.test_dataset.spatial_boundaries(),
             (min(self.lat), max(self.lat), min(self.lon), max(self.lon)))
 
     def test_time_range(self):
         self.assertEqual(
-            self.test_dataset.time_range(), 
+            self.test_dataset.time_range(),
             (dt.datetime(2000, 1, 1), dt.datetime(2000, 12, 1)))
 
     def test_spatial_resolution(self):
@@ -142,12 +145,13 @@ class TestDatasetFunctions(unittest.TestCase):
     def test_temporal_resolution(self):
         self.assertEqual(self.test_dataset.temporal_resolution(), 'monthly')
 
+
 class TestBounds(unittest.TestCase):
     def setUp(self):
         self.bounds = Bounds(-80, 80,                # Lats
-                            -160, 160,               # Lons
-                            dt.datetime(2000, 1, 1), # Start time
-                            dt.datetime(2002, 1, 1)) # End time
+                             -160, 160,               # Lons
+                             dt.datetime(2000, 1, 1),  # Start time
+                             dt.datetime(2002, 1, 1))  # End time
 
     # Latitude tests
     def test_inverted_min_max_lat(self):

--- a/ocw/tests/test_dataset_processor.py
+++ b/ocw/tests/test_dataset_processor.py
@@ -2,7 +2,7 @@
 #  Licensed to the Apache Software Foundation (ASF) under one or more
 #  contributor license agreements.  See the NOTICE file distributed with
 #  this work for additional information regarding copyright ownership.
-#  The ASF licenses this file to You under the Apache License, Version 2.0 
+#  The ASF licenses this file to You under the Apache License, Version 2.0
 #  (the "License"); you may not use this file except in compliance with
 #  the License.  You may obtain a copy of the License at
 #
@@ -28,13 +28,15 @@ import numpy.ma as ma
 import logging
 logging.basicConfig(level=logging.CRITICAL)
 
-class TestEnsemble(unittest.TestCase): 
+
+class TestEnsemble(unittest.TestCase):
     def test_unequal_dataset_shapes(self):
         self.ten_year_dataset = ten_year_monthly_dataset()
         self.two_year_dataset = two_year_daily_dataset()
         with self.assertRaises(ValueError):
-            self.ensemble_dataset = dp.ensemble([self.ten_year_dataset, self.two_year_dataset])
-    
+            self.ensemble_dataset = dp.ensemble(
+                [self.ten_year_dataset, self.two_year_dataset])
+
     def test_ensemble_logic(self):
         self.datasets = []
         self.datasets.append(build_ten_cube_dataset(1))
@@ -47,7 +49,7 @@ class TestEnsemble(unittest.TestCase):
         self.ensemble_flat = self.ensemble.values.flatten()
         self.three_flat = self.three.values.flatten()
         np.testing.assert_array_equal(self.ensemble_flat, self.three_flat)
-    
+
     def test_ensemble_name(self):
         self.ensemble_dataset_name = "Dataset Ensemble"
         self.datasets = []
@@ -55,48 +57,65 @@ class TestEnsemble(unittest.TestCase):
         self.datasets.append(build_ten_cube_dataset(2))
         self.ensemble = dp.ensemble(self.datasets)
         self.assertEquals(self.ensemble.name, self.ensemble_dataset_name)
-        
+
 
 class TestTemporalRebin(unittest.TestCase):
-    
+
     def setUp(self):
         self.ten_year_monthly_dataset = ten_year_monthly_dataset()
-        self.ten_year_annual_times = np.array([datetime.datetime(year, 7, 2) for year in range(2000, 2010)])
+        self.ten_year_annual_times = np.array(
+            [datetime.datetime(year, 7, 2) for year in range(2000, 2010)])
         self.two_years_daily_dataset = two_year_daily_dataset()
-    
+
     def test_monthly_to_annual_rebin(self):
-        annual_dataset = dp.temporal_rebin(self.ten_year_monthly_dataset, "annual")
-        np.testing.assert_array_equal(annual_dataset.times, self.ten_year_annual_times)
-    
+        annual_dataset = dp.temporal_rebin(
+            self.ten_year_monthly_dataset, "annual")
+        np.testing.assert_array_equal(
+            annual_dataset.times, self.ten_year_annual_times)
+
     def test_monthly_to_full_rebin(self):
         full_dataset = dp.temporal_rebin(self.ten_year_monthly_dataset, "full")
         full_times = [datetime.datetime(2005, 1, 1)]
         self.assertEqual(full_dataset.times, full_times)
-    
+
     def test_daily_to_monthly_rebin(self):
-        """This test takes a really long time to run.  TODO: Figure out where the performance drag is"""
-        monthly_dataset = dp.temporal_rebin(self.two_years_daily_dataset, "monthly")
-        bins = list(set([datetime.datetime(time_reading.year, time_reading.month, 15) for time_reading in self.two_years_daily_dataset.times]))
+        """
+        This test takes a really long time to run.
+        TODO: Figure out where the performance drag is
+        """
+        monthly_dataset = dp.temporal_rebin(
+            self.two_years_daily_dataset, "monthly")
+        bins = list(set([datetime.datetime(
+                        time_reading.year, time_reading.month, 15)
+                    for time_reading in self.two_years_daily_dataset.times]))
         bins = np.array(bins)
         bins.sort()
         np.testing.assert_array_equal(monthly_dataset.times, bins)
-    
+
     def test_daily_to_annual_rebin(self):
-        annual_dataset = dp.temporal_rebin(self.two_years_daily_dataset, "annual")
-        bins = list(set([datetime.datetime(time_reading.year, 7, 2) for time_reading in self.two_years_daily_dataset.times]))
+        annual_dataset = dp.temporal_rebin(
+            self.two_years_daily_dataset, "annual")
+        bins = list(set([datetime.datetime(
+                        time_reading.year, 7, 2)
+                    for time_reading in self.two_years_daily_dataset.times]))
         bins = np.array(bins)
         bins.sort()
         np.testing.assert_array_equal(annual_dataset.times, bins)
-   
+
     def test_non_rebin(self):
-        """This will take a monthly dataset and ask for a monthly rebin of 28 days.  The resulting
-        dataset should have the same time values"""
-        monthly_dataset = dp.temporal_rebin(self.ten_year_monthly_dataset, "monthly")
-        bins = list(set([datetime.datetime(time_reading.year, time_reading.month, 15) for time_reading in self.ten_year_monthly_dataset.times]))
+        """
+        This will take a monthly dataset and ask for a monthly rebin of
+        28 days. The resulting dataset should have the same time values
+        """
+        monthly_dataset = dp.temporal_rebin(
+            self.ten_year_monthly_dataset, "monthly")
+        bins = list(set([datetime.datetime(
+                        time_reading.year, time_reading.month, 15)
+                    for time_reading in self.ten_year_monthly_dataset.times]))
         bins = np.array(bins)
         bins.sort()
         np.testing.assert_array_equal(monthly_dataset.times, bins)
-    
+
     def test_variable_propagation(self):
         annual_dataset = dp.temporal_rebin(self.ten_year_monthly_dataset,
                                            "annual")
@@ -109,52 +128,59 @@ class TestTemporalRebin(unittest.TestCase):
 class TestRcmesSpatialRegrid(unittest.TestCase):
 
     def test_return_array_shape(self):
-        spatial_values = np.ones([90,180])
+        spatial_values = np.ones([90, 180])
         spatial_values = ma.array(spatial_values)
-        
+
         lat_range = ma.array(range(-89, 90, 2))
         lon_range = ma.array(range(-179, 180, 2))
-        
+
         lons, lats = np.meshgrid(lon_range, lat_range)
         # Convert these to masked arrays
         lats = ma.array(lats)
         lons = ma.array(lons)
-        
+
         lat2_range = np.array(range(-89, 90, 4))
         lon2_range = np.array(range(-179, 180, 4))
-        
+
         lons2, lats2 = np.meshgrid(lon2_range, lat2_range)
         # Convert to masked arrays
         lats2 = ma.array(lats2)
         lons2 = ma.array(lons2)
 
-        regridded_values = dp._rcmes_spatial_regrid(spatial_values, lats, lons, lats2, lons2)
+        regridded_values = dp._rcmes_spatial_regrid(
+            spatial_values, lats, lons, lats2, lons2)
         self.assertEqual(regridded_values.shape, lats2.shape)
         self.assertEqual(regridded_values.shape, lons2.shape)
 
+
 class TestSpatialRegrid(unittest.TestCase):
-    
+
     def setUp(self):
         self.input_dataset = ten_year_monthly_dataset()
         self.new_lats = np.array(range(-89, 90, 4))
         self.new_lons = np.array(range(-179, 180, 4))
-        self.regridded_dataset = dp.spatial_regrid(self.input_dataset, self.new_lats, self.new_lons)
-
+        self.regridded_dataset = dp.spatial_regrid(
+            self.input_dataset, self.new_lats, self.new_lons)
 
     def test_returned_lats(self):
-        np.testing.assert_array_equal(self.regridded_dataset.lats, self.new_lats)
+        np.testing.assert_array_equal(
+            self.regridded_dataset.lats, self.new_lats)
 
     def test_returned_lons(self):
-        np.testing.assert_array_equal(self.regridded_dataset.lons, self.new_lons)
+        np.testing.assert_array_equal(
+            self.regridded_dataset.lons, self.new_lons)
 
     def test_shape_of_values(self):
         regridded_data_shape = self.regridded_dataset.values.shape
-        expected_data_shape = (len(self.input_dataset.times), len(self.new_lats), len(self.new_lons))
+        expected_data_shape = (len(self.input_dataset.times), len(
+            self.new_lats), len(self.new_lons))
         self.assertSequenceEqual(regridded_data_shape, expected_data_shape)
 
     def test_variable_propagation(self):
         self.assertEquals(self.input_dataset.name, self.regridded_dataset.name)
-        self.assertEquals(self.input_dataset.variable, self.regridded_dataset.variable)
+        self.assertEquals(self.input_dataset.variable,
+                          self.regridded_dataset.variable)
+
 
 class TestNormalizeDatasetDatetimes(unittest.TestCase):
     def setUp(self):
@@ -168,10 +194,12 @@ class TestNormalizeDatasetDatetimes(unittest.TestCase):
         self.assertTrue(all(x.hour == 0 for x in new_ds.times))
 
     def test_montly(self):
-        new_ds = dp.normalize_dataset_datetimes(self.monthly_dataset, 'monthly')
+        new_ds = dp.normalize_dataset_datetimes(
+            self.monthly_dataset, 'monthly')
 
         # Check that all the days have been shifted to the first of the month
         self.assertTrue(all(x.day == 1 for x in new_ds.times))
+
 
 class TestSubset(unittest.TestCase):
     def setUp(self):
@@ -179,29 +207,29 @@ class TestSubset(unittest.TestCase):
         self.name = 'foo'
 
         self.subregion = ds.Bounds(
-            -81, 81, 
-            -161, 161, 
-            datetime.datetime(2001, 1, 1), 
+            -81, 81,
+            -161, 161,
+            datetime.datetime(2001, 1, 1),
             datetime.datetime(2004, 1, 1)
         )
         self.non_exact_spatial_subregion = ds.Bounds(
-            -80.25, 80.5, 
-            -160.25, 160.5, 
-            datetime.datetime(2001, 1, 1), 
+            -80.25, 80.5,
+            -160.25, 160.5,
+            datetime.datetime(2001, 1, 1),
             datetime.datetime(2004, 1, 1)
         )
         self.non_exact_temporal_subregion = ds.Bounds(
-            -80.25, 80.5, 
+            -80.25, 80.5,
             -160.25, 160.5,
-            datetime.datetime(2001, 1, 15), 
+            datetime.datetime(2001, 1, 15),
             datetime.datetime(2004, 2, 15)
         )
 
     def test_subset(self):
         subset = dp.subset(self.subregion, self.target_dataset)
         self.assertEqual(subset.lats.shape[0], 82)
-        self.assertSequenceEqual(list(np.array(range(-81, 82, 2))), 
-                list(subset.lats))
+        self.assertSequenceEqual(list(np.array(range(-81, 82, 2))),
+                                 list(subset.lats))
         self.assertEqual(subset.lons.shape[0], 162)
         self.assertEqual(subset.times.shape[0], 37)
         self.assertEqual(subset.values.shape, (37, 82, 162))
@@ -212,28 +240,31 @@ class TestSubset(unittest.TestCase):
 
     def test_subset_name_propagation(self):
         subset_name = 'foo_subset_name'
-        subset = dp.subset(self.subregion, self.target_dataset,subset_name)
+        subset = dp.subset(self.subregion, self.target_dataset, subset_name)
         self.assertEqual(subset.name, subset_name)
 
     def test_subset_using_non_exact_spatial_bounds(self):
-        index_slices = dp._get_subregion_slice_indices(self.non_exact_spatial_subregion,  self.target_dataset)
-        control_index_slices = {"lat_start"  : 5,
-                                "lat_end"    : 84,
-                                "lon_start"  : 10,
-                                "lon_end"    : 169,
-                                "time_start" : 12, 
-                                "time_end"   : 48}
+        index_slices = dp._get_subregion_slice_indices(
+            self.non_exact_spatial_subregion, self.target_dataset)
+        control_index_slices = {"lat_start": 5,
+                                "lat_end": 84,
+                                "lon_start": 10,
+                                "lon_end": 169,
+                                "time_start": 12,
+                                "time_end": 48}
         self.assertDictEqual(index_slices, control_index_slices)
 
     def test_subset_using_non_exact_temporal_bounds(self):
-        index_slices = dp._get_subregion_slice_indices(self.non_exact_temporal_subregion,  self.target_dataset)
-        control_index_slices = {"lat_start"  : 5,
-                                "lat_end"    : 84,
-                                "lon_start"  : 10,
-                                "lon_end"    : 169,
-                                "time_start" : 13, 
-                                "time_end"   : 49}
+        index_slices = dp._get_subregion_slice_indices(
+            self.non_exact_temporal_subregion, self.target_dataset)
+        control_index_slices = {"lat_start": 5,
+                                "lat_end": 84,
+                                "lon_start": 10,
+                                "lon_end": 169,
+                                "time_start": 13,
+                                "time_end": 49}
         self.assertDictEqual(index_slices, control_index_slices)
+
 
 class TestSafeSubset(unittest.TestCase):
     def setUp(self):
@@ -305,6 +336,7 @@ class TestSafeSubset(unittest.TestCase):
         self.assertEquals(temporal_bounds[0], start)
         self.assertEquals(temporal_bounds[1], end)
 
+
 class TestFailingSubset(unittest.TestCase):
     def setUp(self):
         self.target_dataset = ten_year_monthly_dataset()
@@ -312,9 +344,9 @@ class TestFailingSubset(unittest.TestCase):
         self.target_dataset.lons = np.array(range(-179, 178, 2))
 
         self.subregion = ds.Bounds(
-            -81, 81, 
-            -161, 161, 
-            datetime.datetime(2001, 1, 1), 
+            -81, 81,
+            -161, 161,
+            datetime.datetime(2001, 1, 1),
             datetime.datetime(2004, 1, 1)
         )
 
@@ -348,6 +380,7 @@ class TestFailingSubset(unittest.TestCase):
         with self.assertRaises(ValueError):
             dp.subset(self.subregion, self.target_dataset)
 
+
 class TestNetCDFWrite(unittest.TestCase):
     def setUp(self):
         self.ds = ten_year_monthly_dataset()
@@ -371,44 +404,67 @@ class TestNetCDFWrite(unittest.TestCase):
         np.testing.assert_array_equal(self.ds.times, new_ds.times)
         np.testing.assert_array_equal(self.ds.values, new_ds.values)
 
+
 def ten_year_monthly_dataset():
     lats = np.array(range(-89, 90, 2))
     lons = np.array(range(-179, 180, 2))
     # Ten Years of monthly data
-    times = np.array([datetime.datetime(year, month, 1) for year in range(2000, 2010) for month in range(1, 13)])
+    times = np.array([datetime.datetime(year, month, 1)
+                      for year in range(2000, 2010) for month in range(1, 13)])
     values = np.ones([len(times), len(lats), len(lons)])
-    input_dataset = ds.Dataset(lats, lons, times, values, variable="test variable name", units='test variable units', name='foo')
+    input_dataset = ds.Dataset(lats,
+                               lons,
+                               times,
+                               values,
+                               variable="test variable name",
+                               units='test variable units',
+                               name='foo')
     return input_dataset
+
 
 def ten_year_monthly_15th_dataset():
     lats = np.array(range(-89, 90, 2))
     lons = np.array(range(-179, 180, 2))
     # Ten Years of monthly data
-    times = np.array([datetime.datetime(year, month, 1) for year in range(2000, 2010) for month in range(1, 13)])
+    times = np.array([datetime.datetime(year, month, 1)
+                      for year in range(2000, 2010) for month in range(1, 13)])
     values = np.ones([len(times), len(lats), len(lons)])
-    input_dataset = ds.Dataset(lats, lons, times, values, variable="test variable name", units='test variable units')
+    input_dataset = ds.Dataset(lats,
+                               lons,
+                               times,
+                               values,
+                               variable="test variable name",
+                               units='test variable units')
     return input_dataset
+
 
 def two_year_daily_dataset():
     lats = np.array(range(-89, 90, 2))
     lons = np.array(range(-179, 180, 2))
-    times = np.array([datetime.datetime(2001, 1, 1) + datetime.timedelta(days=d) for d in range(730)])
+    times = np.array([datetime.datetime(2001, 1, 1) +
+                      datetime.timedelta(days=d) for d in range(730)])
     values = np.ones([len(times), len(lats), len(lons)])
-    dataset = ds.Dataset(lats, lons, times, values, variable='random data',units='test variable units')
-    return dataset    
+    dataset = ds.Dataset(lats, lons, times, values,
+                         variable='random data', units='test variable units')
+    return dataset
+
 
 def two_year_daily_2hr_dataset():
     lats = np.array(range(-89, 90, 2))
     lons = np.array(range(-179, 180, 2))
-    times = np.array([datetime.datetime(2001, 1, 1) + datetime.timedelta(days=d, hours=2) for d in range(730)])
+    times = np.array([datetime.datetime(2001, 1, 1) +
+                      datetime.timedelta(days=d, hours=2) for d in range(730)])
     values = np.ones([len(times), len(lats), len(lons)])
-    dataset = ds.Dataset(lats, lons, times, values, variable='random data', units='test variable units')
-    return dataset    
+    dataset = ds.Dataset(lats, lons, times, values,
+                         variable='random data', units='test variable units')
+    return dataset
+
 
 def build_ten_cube_dataset(value):
     lats = np.array(range(-89, 90, 18))
     lons = np.array(range(-179, 180, 36))
-    times = np.array([datetime.datetime(year, 1, 1) for year in range(2000, 2010)])
+    times = np.array([datetime.datetime(year, 1, 1)
+                      for year in range(2000, 2010)])
     values = np.ones([len(times), len(lats), len(lons)])
     values = values * value
     dataset = ds.Dataset(lats, lons, times, values)

--- a/ocw/tests/test_evaluation.py
+++ b/ocw/tests/test_evaluation.py
@@ -24,6 +24,7 @@ from ocw.dataset import Dataset, Bounds
 from ocw.evaluation import Evaluation
 from ocw.metrics import Bias, TemporalStdDev
 
+
 class TestEvaluation(unittest.TestCase):
     def setUp(self):
         self.eval = Evaluation(None, [], [])
@@ -36,8 +37,8 @@ class TestEvaluation(unittest.TestCase):
         self.variable = 'prec'
         self.other_var = 'temp'
         self.test_dataset = Dataset(lat, lon, time, value, self.variable)
-        self.another_test_dataset = Dataset(lat, lon, time, value, 
-                self.other_var)
+        self.another_test_dataset = Dataset(lat, lon, time, value,
+                                            self.other_var)
 
     def test_init(self):
         self.assertEquals(self.eval.ref_dataset, None)
@@ -47,9 +48,9 @@ class TestEvaluation(unittest.TestCase):
 
     def test_full_init(self):
         self.eval = Evaluation(
-                        self.test_dataset,           
-                        [self.test_dataset, self.another_test_dataset], 
-                        [Bias(), Bias(), TemporalStdDev()])                    
+            self.test_dataset,
+            [self.test_dataset, self.another_test_dataset],
+            [Bias(), Bias(), TemporalStdDev()])
 
         self.assertEqual(self.eval.ref_dataset.variable, self.variable)
 
@@ -69,9 +70,9 @@ class TestEvaluation(unittest.TestCase):
 
     def test_valid_subregion(self):
         bound = Bounds(
-                -10, 10, 
-                -20, 20, 
-                dt.datetime(2000, 1, 1), dt.datetime(2001, 1, 1))
+            -10, 10,
+            -20, 20,
+            dt.datetime(2000, 1, 1), dt.datetime(2001, 1, 1))
 
         self.eval.subregions = [bound, bound]
         self.assertEquals(len(self.eval.subregions), 2)
@@ -90,17 +91,17 @@ class TestEvaluation(unittest.TestCase):
     def test_add_dataset(self):
         self.eval.add_dataset(self.test_dataset)
 
-        self.assertEqual(self.eval.target_datasets[0].variable, 
-                self.variable)
+        self.assertEqual(self.eval.target_datasets[0].variable,
+                         self.variable)
 
     def test_add_datasets(self):
         self.eval.add_datasets([self.test_dataset, self.another_test_dataset])
 
         self.assertEqual(len(self.eval.target_datasets), 2)
-        self.assertEqual(self.eval.target_datasets[0].variable, 
-                self.variable)
-        self.assertEqual(self.eval.target_datasets[1].variable, 
-                self.other_var)
+        self.assertEqual(self.eval.target_datasets[0].variable,
+                         self.variable)
+        self.assertEqual(self.eval.target_datasets[1].variable,
+                         self.other_var)
 
     def test_add_metric(self):
         # Add a "binary" metric
@@ -117,9 +118,10 @@ class TestEvaluation(unittest.TestCase):
         self.assertEqual(len(self.eval.metrics), 0)
         self.eval.add_metrics([Bias(), Bias()])
         self.assertEqual(len(self.eval.metrics), 2)
-    
+
     def test_bias_output_shape(self):
-        bias_eval = Evaluation(self.test_dataset, [self.another_test_dataset], [Bias()])
+        bias_eval = Evaluation(self.test_dataset, [
+                               self.another_test_dataset], [Bias()])
         bias_eval.run()
         input_shape = tuple(self.test_dataset.values.shape)
         bias_results_shape = tuple(bias_eval.results[0][0].shape)
@@ -128,7 +130,8 @@ class TestEvaluation(unittest.TestCase):
     def test_result_shape(self):
         bias_eval = Evaluation(
             self.test_dataset,
-            [self.another_test_dataset, self.another_test_dataset, self.another_test_dataset],
+            [self.another_test_dataset, self.another_test_dataset,
+                self.another_test_dataset],
             [Bias(), Bias()]
         )
         bias_eval.run()
@@ -141,22 +144,23 @@ class TestEvaluation(unittest.TestCase):
     def test_unary_result_shape(self):
         new_eval = Evaluation(
             self.test_dataset,
-            [self.another_test_dataset, self.another_test_dataset, self.another_test_dataset, self.another_test_dataset],
+            [self.another_test_dataset, self.another_test_dataset,
+                self.another_test_dataset, self.another_test_dataset],
             [TemporalStdDev()]
         )
         new_eval.run()
 
         # Expected result shape is
         # [stddev] where stddev.shape[0] = number of datasets
-        
+
         self.assertTrue(len(new_eval.unary_results) == 1)
         self.assertTrue(new_eval.unary_results[0].shape[0] == 5)
 
     def test_subregion_result_shape(self):
         bound = Bounds(
-                10, 18, 
-                100, 108, 
-                dt.datetime(2000, 1, 1), dt.datetime(2000, 3, 1))
+            10, 18,
+            100, 108,
+            dt.datetime(2000, 1, 1), dt.datetime(2000, 3, 1))
 
         bias_eval = Evaluation(
             self.test_dataset,
@@ -175,13 +179,13 @@ class TestEvaluation(unittest.TestCase):
         self.assertTrue(len(bias_eval.results) == 1)
         self.assertTrue(len(bias_eval.results[0]) == 1)
         self.assertTrue(bias_eval.results[0][0].shape[0] == 2)
-        self.assertTrue(type(bias_eval.results) == type([]))
+        self.assertTrue(isinstance(bias_eval.results, type([])))
 
     def test_subregion_unary_result_shape(self):
         bound = Bounds(
-                10, 18, 
-                100, 108, 
-                dt.datetime(2000, 1, 1), dt.datetime(2000, 3, 1))
+            10, 18,
+            100, 108,
+            dt.datetime(2000, 1, 1), dt.datetime(2000, 3, 1))
 
         new_eval = Evaluation(
             self.test_dataset,
@@ -197,11 +201,15 @@ class TestEvaluation(unittest.TestCase):
         #           [3, temporalstddev.run(reference).shape],
         #       ]
         # ]
-        self.assertTrue(len(new_eval.unary_results) == 5)  # number of subregions
-        self.assertTrue(len(new_eval.unary_results[0]) == 2) # number of metrics
-        self.assertTrue(type(new_eval.unary_results) == type([]))
-        self.assertTrue(new_eval.unary_results[0][0].shape[0] == 3) # number of datasets (ref + target)
+
+        # 5 = number of subregions
+        self.assertTrue(len(new_eval.unary_results) == 5)
+        # number of metrics
+        self.assertTrue(len(new_eval.unary_results[0]) == 2)
+        self.assertTrue(isinstance(new_eval.unary_results, type([])))
+        # number of datasets (ref + target)
+        self.assertTrue(new_eval.unary_results[0][0].shape[0] == 3)
 
 
-if __name__  == '__main__':
+if __name__ == '__main__':
     unittest.main()

--- a/ocw/tests/test_local.py
+++ b/ocw/tests/test_local.py
@@ -33,7 +33,8 @@ class test_load_file(unittest.TestCase):
         self.latitudes = self.netCDF_file.variables['latitude'][:]
         self.longitudes = self.netCDF_file.variables['longitude'][:]
         self.values = self.netCDF_file.variables['value'][:]
-        self.variable_name_list = ['latitude', 'longitude', 'time', 'level', 'value']
+        self.variable_name_list = ['latitude',
+                                   'longitude', 'time', 'level', 'value']
         self.possible_value_name = ['latitude', 'longitude', 'time', 'level']
 
     def tearDown(self):
@@ -41,21 +42,26 @@ class test_load_file(unittest.TestCase):
 
     def test_function_load_file_lats(self):
         """To test load_file function for latitudes"""
-        self.assertItemsEqual(local.load_file(self.file_path, "value").lats, self.latitudes)
+        self.assertItemsEqual(local.load_file(
+            self.file_path, "value").lats, self.latitudes)
 
     def test_function_load_file_lons(self):
         """To test load_file function for longitudes"""
-        self.assertItemsEqual(local.load_file(self.file_path, "value").lons, self.longitudes)
+        self.assertItemsEqual(local.load_file(
+            self.file_path, "value").lons, self.longitudes)
 
     def test_function_load_file_times(self):
         """To test load_file function for times"""
-        newTimes = datetime.datetime(2001, 01, 01), datetime.datetime(2001, 02, 01), datetime.datetime(2001, 03, 01)
-        self.assertItemsEqual(local.load_file(self.file_path, "value").times, newTimes)
+        newTimes = datetime.datetime(2001, 01, 01), datetime.datetime(
+            2001, 02, 01), datetime.datetime(2001, 03, 01)
+        self.assertItemsEqual(local.load_file(
+            self.file_path, "value").times, newTimes)
 
     def test_function_load_file_values(self):
         """To test load_file function for values"""
         new_values = self.values[:, 0, :, :]
-        self.assertTrue(numpy.allclose(local.load_file(self.file_path, "value").values, new_values))
+        self.assertTrue(numpy.allclose(local.load_file(
+            self.file_path, "value").values, new_values))
 
     def test_custom_dataset_name(self):
         """Test adding a custom name to a dataset"""
@@ -84,18 +90,16 @@ class test_get_netcdf_variable_names(unittest.TestCase):
         os.remove(self.test_model)
 
     def test_valid_latitude(self):
-        self.lat = local._get_netcdf_variable_name(
-            local.LAT_NAMES,
-            self.netcdf,
-            "tasmax")
+        self.lat = local._get_netcdf_variable_name(local.LAT_NAMES,
+                                                   self.netcdf,
+                                                   "tasmax")
         self.assertEquals(self.lat, "rlat")
 
     def test_invalid_dimension_latitude(self):
         self.netcdf = netCDF4.Dataset(self.invalid_netcdf_path, mode='r')
-        self.lat = local._get_netcdf_variable_name(
-            local.LAT_NAMES,
-            self.netcdf,
-            "value")
+        self.lat = local._get_netcdf_variable_name(local.LAT_NAMES,
+                                                   self.netcdf,
+                                                   "value")
         self.assertEquals(self.lat, "latitude")
 
     def test_dimension_variable_name_mismatch(self):
@@ -108,10 +112,9 @@ class test_get_netcdf_variable_names(unittest.TestCase):
 
     def test_no_match_latitude(self):
         with self.assertRaises(ValueError):
-            self.lat = local._get_netcdf_variable_name(
-                ['notAVarName'],
-                self.netcdf,
-                "tasmax")
+            self.lat = local._get_netcdf_variable_name(['notAVarName'],
+                                                       self.netcdf,
+                                                       "tasmax")
 
 
 def create_netcdf_object():
@@ -128,7 +131,12 @@ def create_netcdf_object():
     longitudes = netCDF_file.createVariable('longitude', 'd', ('lon_dim',))
     times = netCDF_file.createVariable('time', 'd', ('time_dim',))
     levels = netCDF_file.createVariable('level', 'd', ('level_dim',))
-    values = netCDF_file.createVariable('value', 'd', ('time_dim', 'level_dim', 'lat_dim', 'lon_dim'))
+    values = netCDF_file.createVariable('value', 'd',
+                                        ('time_dim',
+                                         'level_dim',
+                                         'lat_dim',
+                                         'lon_dim')
+                                        )
 
     # To latitudes and longitudes for five values
     latitudes_data = range(0, 5)
@@ -140,7 +148,8 @@ def create_netcdf_object():
     # Create 150 values
     values_data = numpy.array([i for i in range(150)])
     # Reshape values to 4D array (level, time, lats, lons)
-    values_data = values_data.reshape(len(times_data), len(levels_data), len(latitudes_data), len(longitudes_data))
+    values_data = values_data.reshape(len(times_data), len(
+        levels_data), len(latitudes_data), len(longitudes_data))
 
     # Ingest values to netCDF file
     latitudes[:] = latitudes_data
@@ -169,7 +178,13 @@ def create_invalid_dimensions_netcdf_object():
     longitudes = netCDF_file.createVariable('longitude', 'd', ('lon_dim',))
     times = netCDF_file.createVariable('time', 'd', ('time_dim',))
     levels = netCDF_file.createVariable('level', 'd', ('level_dim',))
-    values = netCDF_file.createVariable('value', 'd', ('level_dim', 'time_dim', 'lat_dim', 'lon_dim'))
+    values = netCDF_file.createVariable('value',
+                                        'd',
+                                        ('level_dim',
+                                         'time_dim',
+                                         'lat_dim',
+                                         'lon_dim')
+                                        )
     # To latitudes and longitudes for five values
     latitudes = range(0, 5)
     longitudes = range(200, 205)
@@ -180,7 +195,8 @@ def create_invalid_dimensions_netcdf_object():
     # Create 150 values
     values = numpy.array([i for i in range(150)])
     # Reshape values to 4D array (level, time, lats, lons)
-    values = values.reshape(len(levels), len(times), len(latitudes), len(longitudes))
+    values = values.reshape(len(levels), len(
+        times), len(latitudes), len(longitudes))
     # Ingest values to netCDF file
     latitudes[:] = latitudes
     longitudes[:] = longitudes

--- a/ocw/tests/test_metrics.py
+++ b/ocw/tests/test_metrics.py
@@ -27,38 +27,50 @@ import numpy as np
 import numpy.ma as ma
 import numpy.testing as npt
 
+
 class TestBias(unittest.TestCase):
     '''Test the metrics.Bias metric.'''
+
     def setUp(self):
         self.bias = metrics.Bias()
         # Initialize reference dataset
         self.reference_lat = np.array([10, 12, 14, 16, 18])
         self.reference_lon = np.array([100, 102, 104, 106, 108])
-        self.reference_time = np.array([dt.datetime(2000, x, 1) for x in range(1, 13)])
+        self.reference_time = np.array(
+            [dt.datetime(2000, x, 1) for x in range(1, 13)])
         flat_array = np.array(range(300))
         self.reference_value = flat_array.reshape(12, 5, 5)
         self.reference_variable = 'prec'
-        self.reference_dataset = Dataset(self.reference_lat, self.reference_lon,
-            self.reference_time, self.reference_value, self.reference_variable)
+        self.reference_dataset = Dataset(self.reference_lat,
+                                         self.reference_lon,
+                                         self.reference_time,
+                                         self.reference_value,
+                                         self.reference_variable)
         # Initialize target dataset
         self.target_lat = np.array([1, 2, 4, 6, 8])
         self.target_lon = np.array([10, 12, 14, 16, 18])
-        self.target_time = np.array([dt.datetime(2001, x, 1) for x in range(1, 13)])
+        self.target_time = np.array(
+            [dt.datetime(2001, x, 1) for x in range(1, 13)])
         flat_array = np.array(range(300, 600))
         self.target_value = flat_array.reshape(12, 5, 5)
         self.target_variable = 'tasmax'
-        self.target_dataset = Dataset(self.target_lat, self.target_lon, self.target_time,
-            self.target_value, self.target_variable)
-
+        self.target_dataset = Dataset(self.target_lat,
+                                      self.target_lon,
+                                      self.target_time,
+                                      self.target_value,
+                                      self.target_variable)
 
     def test_function_run(self):
         '''Test bias function between reference dataset and target dataset.'''
         expected_result = np.zeros((12, 5, 5), dtype=np.int)
         expected_result.fill(-300)
-        np.testing.assert_array_equal(self.bias.run(self.target_dataset, self.reference_dataset), expected_result)
+        np.testing.assert_array_equal(self.bias.run(
+            self.target_dataset, self.reference_dataset), expected_result)
+
 
 class TestSpatialPatternTaylorDiagram(unittest.TestCase):
     '''Test the metrics.SpatialPatternTaylorDiagram'''
+
     def setUp(self):
         self.taylor_diagram = metrics.SpatialPatternTaylorDiagram()
         self.ref_dataset = Dataset(
@@ -80,32 +92,40 @@ class TestSpatialPatternTaylorDiagram(unittest.TestCase):
         )
 
     def test_function_run(self):
-        np.testing.assert_array_equal(self.taylor_diagram.run(self.ref_dataset, self.tar_dataset), ma.array([0.4,1.0]))
+        np.testing.assert_array_equal(self.taylor_diagram.run(
+            self.ref_dataset, self.tar_dataset), ma.array([0.4, 1.0]))
+
 
 class TestTemporalStdDev(unittest.TestCase):
     '''Test the metrics.TemporalStdDev metric.'''
+
     def setUp(self):
         self.temporal_std_dev = metrics.TemporalStdDev()
         # Initialize target dataset
         self.target_lat = np.array([10, 12, 14, 16, 18])
         self.target_lon = np.array([100, 102, 104, 106, 108])
-        self.target_time = np.array([dt.datetime(2000, x, 1) for x in range(1, 13)])
+        self.target_time = np.array(
+            [dt.datetime(2000, x, 1) for x in range(1, 13)])
         flat_array = np.array(range(300))
         self.target_value = flat_array.reshape(12, 5, 5)
         self.target_variable = 'prec'
-        self.target_dataset = Dataset(self.target_lat, self.target_lon, self.target_time,
-            self.target_value, self.target_variable)
-
+        self.target_dataset = Dataset(self.target_lat,
+                                      self.target_lon,
+                                      self.target_time,
+                                      self.target_value,
+                                      self.target_variable)
 
     def test_function_run(self):
         '''Test TemporalStdDev function for target dataset.'''
         expected_result = np.zeros((5, 5),)
         expected_result.fill(90.13878189)
-        npt.assert_almost_equal(self.temporal_std_dev.run(self.target_dataset), expected_result)
+        npt.assert_almost_equal(self.temporal_std_dev.run(
+            self.target_dataset), expected_result)
 
 
 class TestStdDevRatio(unittest.TestCase):
     '''Test the metrics.StdDevRatio metric'''
+
     def setUp(self):
         self.std_dev_ratio = metrics.StdDevRatio()
         self.ref_dataset = Dataset(
@@ -127,11 +147,13 @@ class TestStdDevRatio(unittest.TestCase):
         )
 
     def test_function_run(self):
-        self.assertTrue(self.std_dev_ratio.run(self.ref_dataset, self.tar_dataset), 0.4)
+        self.assertTrue(self.std_dev_ratio.run(
+            self.ref_dataset, self.tar_dataset), 0.4)
 
 
 class TestPatternCorrelation(unittest.TestCase):
     '''Test the metrics.PatternCorrelation metric'''
+
     def setUp(self):
         self.pattern_correlation = metrics.PatternCorrelation()
         self.ref_dataset = Dataset(
@@ -153,12 +175,14 @@ class TestPatternCorrelation(unittest.TestCase):
         )
 
     def test_function_run(self):
-        pattern = self.pattern_correlation.run(self.tar_dataset, self.ref_dataset)
+        pattern = self.pattern_correlation.run(
+            self.tar_dataset, self.ref_dataset)
         self.assertEqual(pattern, 1.0)
 
 
 class TestTemporalCorrelation(unittest.TestCase):
     '''Test the metrics.TemporalCorrelation metric.'''
+
     def setUp(self):
         # Set metric.
         self.metric = metrics.TemporalCorrelation()
@@ -169,8 +193,11 @@ class TestTemporalCorrelation(unittest.TestCase):
                                    for x in range(1, 13)])
         self.ref_values = np.array(range(300)).reshape(12, 5, 5)
         self.ref_variable = "ref"
-        self.ref_dataset = Dataset(self.ref_lats, self.ref_lons,
-            self.ref_times, self.ref_values, self.ref_variable)
+        self.ref_dataset = Dataset(self.ref_lats,
+                                   self.ref_lons,
+                                   self.ref_times,
+                                   self.ref_values,
+                                   self.ref_variable)
         # Initialize target datasets.
         self.tgt_lats = np.array([10, 20, 30, 40, 50])
         self.tgt_lons = np.array([5, 15, 25, 35, 45])
@@ -179,10 +206,16 @@ class TestTemporalCorrelation(unittest.TestCase):
         self.tgt_variable = "tgt"
         self.tgt_values_inc = np.array(range(300, 600)).reshape(12, 5, 5)
         self.tgt_values_dec = np.array(range(299, -1, -1)).reshape(12, 5, 5)
-        self.tgt_dataset_inc = Dataset(self.tgt_lats, self.tgt_lons,
-            self.tgt_times, self.tgt_values_inc, self.tgt_variable)
-        self.tgt_dataset_dec = Dataset(self.tgt_lats, self.tgt_lons,
-            self.tgt_times, self.tgt_values_dec, self.tgt_variable)
+        self.tgt_dataset_inc = Dataset(self.tgt_lats,
+                                       self.tgt_lons,
+                                       self.tgt_times,
+                                       self.tgt_values_inc,
+                                       self.tgt_variable)
+        self.tgt_dataset_dec = Dataset(self.tgt_lats,
+                                       self.tgt_lons,
+                                       self.tgt_times,
+                                       self.tgt_values_dec,
+                                       self.tgt_variable)
 
     def test_identical_inputs(self):
         expected = np.ones(25).reshape(5, 5)
@@ -202,35 +235,49 @@ class TestTemporalCorrelation(unittest.TestCase):
 
 class TestTemporalMeanBias(unittest.TestCase):
     '''Test the metrics.TemporalMeanBias metric.'''
+
     def setUp(self):
         self.mean_bias = metrics.TemporalMeanBias()
         # Initialize reference dataset
         self.reference_lat = np.array([10, 12, 14, 16, 18])
         self.reference_lon = np.array([100, 102, 104, 106, 108])
-        self.reference_time = np.array([dt.datetime(2000, x, 1) for x in range(1, 13)])
+        self.reference_time = np.array(
+            [dt.datetime(2000, x, 1) for x in range(1, 13)])
         flat_array = np.array(range(300))
         self.reference_value = flat_array.reshape(12, 5, 5)
         self.reference_variable = 'prec'
-        self.reference_dataset = Dataset(self.reference_lat, self.reference_lon,
-            self.reference_time, self.reference_value, self.reference_variable)
+        self.reference_dataset = Dataset(self.reference_lat,
+                                         self.reference_lon,
+                                         self.reference_time,
+                                         self.reference_value,
+                                         self.reference_variable)
         # Initialize target dataset
         self.target_lat = np.array([1, 2, 4, 6, 8])
         self.target_lon = np.array([10, 12, 14, 16, 18])
-        self.target_time = np.array([dt.datetime(2001, x, 1) for x in range(1, 13)])
+        self.target_time = np.array(
+            [dt.datetime(2001, x, 1) for x in range(1, 13)])
         flat_array = np.array(range(300, 600))
         self.target_value = flat_array.reshape(12, 5, 5)
         self.target_variable = 'tasmax'
-        self.target_dataset = Dataset(self.target_lat, self.target_lon, self.target_time,
-            self.target_value, self.target_variable)
+        self.target_dataset = Dataset(self.target_lat,
+                                      self.target_lon,
+                                      self.target_time,
+                                      self.target_value,
+                                      self.target_variable)
 
     def test_function_run(self):
-        '''Test mean bias function between reference dataset and target dataset.'''
+        '''
+        Test mean bias function between reference dataset and target dataset.
+        '''
         expected_result = np.zeros((5, 5), dtype=np.int)
         expected_result.fill(-300)
-        np.testing.assert_array_equal(self.mean_bias.run(self.target_dataset,self.reference_dataset), expected_result)
+        np.testing.assert_array_equal(self.mean_bias.run(
+            self.target_dataset, self.reference_dataset), expected_result)
+
 
 class TestRMSError(unittest.TestCase):
     '''Test the metrics.RMSError metric.'''
+
     def setUp(self):
         # Set metric.
         self.metric = metrics.RMSError()
@@ -241,17 +288,23 @@ class TestRMSError(unittest.TestCase):
                                    for x in range(1, 13)])
         self.ref_values = np.array([4] * 300).reshape(12, 5, 5)
         self.ref_variable = "ref"
-        self.ref_dataset = Dataset(self.ref_lats, self.ref_lons,
-            self.ref_times, self.ref_values, self.ref_variable)
+        self.ref_dataset = Dataset(self.ref_lats,
+                                   self.ref_lons,
+                                   self.ref_times,
+                                   self.ref_values,
+                                   self.ref_variable)
         # Initialize target dataset.
         self.tgt_lats = np.array([10, 20, 30, 40, 50])
         self.tgt_lons = np.array([5, 15, 25, 35, 45])
         self.tgt_times = np.array([dt.datetime(2000, x, 1)
-                                    for x in range(1, 13)])
+                                   for x in range(1, 13)])
         self.tgt_values = np.array([2] * 300).reshape(12, 5, 5)
         self.tgt_variable = "tgt"
-        self.tgt_dataset = Dataset(self.tgt_lats, self.tgt_lons,
-            self.tgt_times, self.tgt_values, self.tgt_variable)
+        self.tgt_dataset = Dataset(self.tgt_lats,
+                                   self.tgt_lons,
+                                   self.tgt_times,
+                                   self.tgt_values,
+                                   self.tgt_variable)
 
     def test_function_run(self):
         result = self.metric.run(self.ref_dataset, self.tgt_dataset)
@@ -260,4 +313,3 @@ class TestRMSError(unittest.TestCase):
 
 if __name__ == '__main__':
     unittest.main()
-

--- a/ocw/tests/test_plotter.py
+++ b/ocw/tests/test_plotter.py
@@ -19,8 +19,9 @@
 
 import unittest
 
+
 class TestPlotter(unittest.TestCase):
     pass
 
-if __name__  == '__main__':
+if __name__ == '__main__':
     unittest.main()

--- a/ocw/tests/test_rcmed.py
+++ b/ocw/tests/test_rcmed.py
@@ -21,8 +21,9 @@ import numpy
 import pickle
 import inspect
 import os
-import test_rcmed # Import test_rcmed so we can use inspect to get the path
+import test_rcmed  # Import test_rcmed so we can use inspect to get the path
 import ocw.data_source.rcmed as rcmed
+
 
 class CustomAssertions:
     # Custom Assertions to handle Numpy Arrays
@@ -31,7 +32,6 @@ class CustomAssertions:
 
 
 class test_rcmed(unittest.TestCase, CustomAssertions):
-
 
     def setUp(self):
         self.dataset_id = 2
@@ -42,14 +42,16 @@ class test_rcmed(unittest.TestCase, CustomAssertions):
         self.max_lon = 15
         self.start_time = datetime.datetime(2002, 8, 1)
         self.end_time = datetime.datetime(2002, 10, 1)
-        #start and end time for URL to query database is the beginning and end of start_time and end_time
+        # start and end time for URL to query database is the beginning and end
+        # of start_time and end_time
         self.start_time_for_url = "20020801T0000Z"
         self.end_time_for_url = "20021001T2359Z"
         self.url = "http://rcmes.jpl.nasa.gov/query-api/query.php?"
-        self.lats=numpy.arange(50.5, 70, 1)
-        self.lons=numpy.arange(1.5, 15, 1)
-        #In this parameter, two days of 10/20 and 10/21 have been missed.
-        self.times_list=[datetime.datetime(2002, 8, 31) + datetime.timedelta(days=x) for x in range(0, 62)]
+        self.lats = numpy.arange(50.5, 70, 1)
+        self.lons = numpy.arange(1.5, 15, 1)
+        # In this parameter, two days of 10/20 and 10/21 have been missed.
+        self.times_list = [datetime.datetime(
+            2002, 8, 31) + datetime.timedelta(days=x) for x in range(0, 62)]
         self.times_list.remove(datetime.datetime(2002, 10, 20))
         self.times_list.remove(datetime.datetime(2002, 10, 21))
         self.times = numpy.array(self.times_list)
@@ -61,64 +63,119 @@ class test_rcmed(unittest.TestCase, CustomAssertions):
         self.file_path = self.file_path.split('test_rcmed')[0]
 
         # Grab the parameter values file
-        params_file = open(os.path.join(self.file_path, "parameters_values.p"), "rb")
+        params_file = open(os.path.join(
+            self.file_path, "parameters_values.p"), "rb")
         self.values = pickle.load(params_file)
         # Grab the parameter metadata file
-        meta_file = open(os.path.join(self.file_path, "parameters_metadata_output.p"), "rb")
+        meta_file = open(os.path.join(
+            self.file_path, "parameters_metadata_output.p"), "rb")
         self.param_metadata_output = pickle.load(meta_file)
 
-
     def return_text(self, url):
-        if url == self.url + ("datasetId={0}&parameterId={1}&latMin={2}&latMax={3}"
-                              "&lonMin={4}&lonMax={5}&timeStart={6}&timeEnd={7}").format(
-                               self.dataset_id, self.parameter_id, self.min_lat,
-                               self.max_lat, self.min_lon, self.max_lon,
-                               self.start_time_for_url, self.end_time_for_url):
-            return open(os.path.join(self.file_path, "parameter_dataset_text.txt"))
+        if url == self.url + ("datasetId={0}&"
+                              "parameterId={1}&"
+                              "latMin={2}&"
+                              "latMax={3}&"
+                              "lonMin={4}&"
+                              "lonMax={5}&"
+                              "timeStart={6}&"
+                              "timeEnd={7}").format(self.dataset_id,
+                                                    self.parameter_id,
+                                                    self.min_lat,
+                                                    self.max_lat,
+                                                    self.min_lon,
+                                                    self.max_lon,
+                                                    self.start_time_for_url,
+                                                    self.end_time_for_url):
+            return open(os.path.join(self.file_path,
+                                     "parameter_dataset_text.txt"))
         elif url == self.url + "&param_info=yes":
-            return open(os.path.join(self.file_path, "parameters_metadata_text.txt"))
+            return open(os.path.join(self.file_path,
+                                     "parameters_metadata_text.txt"))
         else:
-            raise Exception ("The URL is not acceptable.")
-
+            raise Exception("The URL is not acceptable.")
 
     def test_function_get_parameters_metadata(self):
         rcmed.urllib2.urlopen = self.return_text
-        self.assertEqual(rcmed.get_parameters_metadata(), self.param_metadata_output)
-
+        self.assertEqual(rcmed.get_parameters_metadata(),
+                         self.param_metadata_output)
 
     def test_function_parameter_dataset_lats_monthly(self):
         self.dataset_id = 6
         self.parameter_id = 32
         self.end_time_for_url = "20021031T0000Z"
         rcmed.urllib2.urlopen = self.return_text
-        self.assert1DArraysEqual(rcmed.parameter_dataset(self.dataset_id, self.parameter_id, self.min_lat, self.max_lat, self.min_lon, self.max_lon, self.start_time, self.end_time).lats, self.lats)
-
+        self.assert1DArraysEqual(rcmed.parameter_dataset(self.dataset_id,
+                                                         self.parameter_id,
+                                                         self.min_lat,
+                                                         self.max_lat,
+                                                         self.min_lon,
+                                                         self.max_lon,
+                                                         self.start_time,
+                                                         self.end_time).lats,
+                                 self.lats)
 
     def test_function_parameter_dataset_lats(self):
         rcmed.urllib2.urlopen = self.return_text
-        self.assert1DArraysEqual(rcmed.parameter_dataset(self.dataset_id, self.parameter_id, self.min_lat, self.max_lat, self.min_lon, self.max_lon, self.start_time, self.end_time).lats, self.lats)
-
+        self.assert1DArraysEqual(rcmed.parameter_dataset(self.dataset_id,
+                                                         self.parameter_id,
+                                                         self.min_lat,
+                                                         self.max_lat,
+                                                         self.min_lon,
+                                                         self.max_lon,
+                                                         self.start_time,
+                                                         self.end_time).lats,
+                                 self.lats)
 
     def test_function_parameter_dataset_lons(self):
         rcmed.urllib2.urlopen = self.return_text
-        self.assert1DArraysEqual(rcmed.parameter_dataset(self.dataset_id, self.parameter_id, self.min_lat, self.max_lat, self.min_lon, self.max_lon, self.start_time, self.end_time).lons, self.lons)
-
+        self.assert1DArraysEqual(rcmed.parameter_dataset(self.dataset_id,
+                                                         self.parameter_id,
+                                                         self.min_lat,
+                                                         self.max_lat,
+                                                         self.min_lon,
+                                                         self.max_lon,
+                                                         self.start_time,
+                                                         self.end_time).lons,
+                                 self.lons)
 
     def test_function_parameter_dataset_times(self):
         rcmed.urllib2.urlopen = self.return_text
-        self.assert1DArraysEqual(rcmed.parameter_dataset(self.dataset_id, self.parameter_id, self.min_lat, self.max_lat, self.min_lon, self.max_lon, self.start_time, self.end_time).times, self.times)
-
+        self.assert1DArraysEqual(rcmed.parameter_dataset(self.dataset_id,
+                                                         self.parameter_id,
+                                                         self.min_lat,
+                                                         self.max_lat,
+                                                         self.min_lon,
+                                                         self.max_lon,
+                                                         self.start_time,
+                                                         self.end_time).times,
+                                 self.times)
 
     def test_function_parameter_dataset_values(self):
         rcmed.urllib2.urlopen = self.return_text
-        self.assert1DArraysEqual(rcmed.parameter_dataset(self.dataset_id, self.parameter_id, self.min_lat, self.max_lat, self.min_lon, self.max_lon, self.start_tnamime, self.end_time).values.flatten(), self.values.flatten())
+        self.assert1DArraysEqual(rcmed.parameter_dataset(self.dataset_id,
+                                                         self.parameter_id,
+                                                         self.min_lat,
+                                                         self.max_lat,
+                                                         self.min_lon,
+                                                         self.max_lon,
+                                                         self.start_time,
+                                                         self.end_time)
+                                 .values.flatten(),
+                                 self.values.flatten())
 
-
-    def test_function_parameter_dataset_values(self):
+    def test_function_parameter_dataset_name(self):
         rcmed.urllib2.urlopen = self.return_text
-        ds = rcmed.parameter_dataset(self.dataset_id, self.parameter_id, self.min_lat, self.max_lat, self.min_lon, self.max_lon, self.start_time, self.end_time, name='foo')
+        ds = rcmed.parameter_dataset(self.dataset_id,
+                                     self.parameter_id,
+                                     self.min_lat,
+                                     self.max_lat,
+                                     self.min_lon,
+                                     self.max_lon,
+                                     self.start_time,
+                                     self.end_time,
+                                     name='foo')
         self.assertEquals(ds.name, 'foo')
-
 
     def test_dataset_origin(self):
         rcmed.urllib2.urlopen = self.return_text

--- a/ocw/tests/test_utils.py
+++ b/ocw/tests/test_utils.py
@@ -16,7 +16,6 @@
 # under the License.
 
 import unittest
-import urllib
 import os
 import datetime
 from dateutil.relativedelta import relativedelta
@@ -27,11 +26,14 @@ import numpy as np
 from ocw.dataset import Dataset
 import ocw.utils as utils
 
+
 class TestDecodeTimes(unittest.TestCase):
-    test_model = os.getcwd() + '/ocw-ui/backend/tests/example_data/lat_lon_time.nc'
+    test_model = os.getcwd() + '/ocw-ui/backend/tests/example_data/'\
+                               'lat_lon_time.nc'
 
     def setUp(self):
-        self.netcdf = netCDF4.Dataset(os.path.abspath(self.test_model), mode='r')
+        self.netcdf = netCDF4.Dataset(
+            os.path.abspath(self.test_model), mode='r')
 
     def test_proper_return_format(self):
         times = utils.decode_time_values(self.netcdf, 'time')
@@ -39,12 +41,15 @@ class TestDecodeTimes(unittest.TestCase):
         self.assertTrue(all([type(x) is datetime.datetime for x in times]))
 
     def test_valid_time_processing(self):
-        start_time = datetime.datetime.strptime('1989-01-01 00:00:00', '%Y-%m-%d %H:%M:%S')
-        end_time = datetime.datetime.strptime('2008-12-01 00:00:00', '%Y-%m-%d %H:%M:%S')
+        start_time = datetime.datetime.strptime(
+            '1989-01-01 00:00:00', '%Y-%m-%d %H:%M:%S')
+        end_time = datetime.datetime.strptime(
+            '2008-12-01 00:00:00', '%Y-%m-%d %H:%M:%S')
         times = utils.decode_time_values(self.netcdf, 'time')
 
         self.assertEquals(times[0], start_time)
         self.assertEquals(times[-1], end_time)
+
 
 class TestTimeUnitsParse(unittest.TestCase):
     def test_valid_parse(self):
@@ -59,10 +64,12 @@ class TestTimeUnitsParse(unittest.TestCase):
             'parsecs since a made up date'
         )
 
+
 class TestTimeBaseParse(unittest.TestCase):
     def test_valid_time_base(self):
         base_time = utils.parse_time_base('days since 1988-06-10 00:00:00')
-        start_time = datetime.datetime.strptime('1988-06-10 00:00:00', '%Y-%m-%d %H:%M:%S')
+        start_time = datetime.datetime.strptime(
+            '1988-06-10 00:00:00', '%Y-%m-%d %H:%M:%S')
 
         self.assertEquals(base_time, start_time)
 
@@ -73,10 +80,11 @@ class TestTimeBaseParse(unittest.TestCase):
             'days since 1988g06g10g00g00g00'
         )
 
+
 class TestBaseTimeStringParse(unittest.TestCase):
     def test_valid_time_base_string_parse(self):
         base = utils.parse_base_time_string('days since 1988-06-10 00:00:00')
-        
+
         self.assertEquals(base, '1988-06-10 00:00:00')
 
     def test_invalid_time_base_string_parse(self):
@@ -86,13 +94,15 @@ class TestBaseTimeStringParse(unittest.TestCase):
             'this string is not valid'
         )
 
+
 class TestNormalizeLatLonValues(unittest.TestCase):
     def setUp(self):
         times = np.array([datetime.datetime(2000, x, 1) for x in range(1, 13)])
         self.lats = np.arange(-30, 30)
         self.lons = np.arange(360)
         flat_array = np.arange(len(times) * len(self.lats) * len(self.lons))
-        self.values = flat_array.reshape(len(times), len(self.lats), len(self.lons))
+        self.values = flat_array.reshape(
+            len(times), len(self.lats), len(self.lons))
         self.lats2 = np.array([-30, 0, 30])
         self.lons2 = np.array([0, 100, 200, 300])
         self.values2 = np.arange(12).reshape(3, 4)
@@ -104,15 +114,17 @@ class TestNormalizeLatLonValues(unittest.TestCase):
                                                             self.lons,
                                                             self.values)
         np.testing.assert_array_equal(lons, np.arange(-180, 180))
-        
+
     def test_lats_reversed(self):
         lons2 = np.arange(-180, 180)
         lats, lons, values = utils.normalize_lat_lon_values(self.lats[::-1],
                                                             lons2,
-                                                            self.values[:, ::-1, :])
+                                                            self.values[:,
+                                                                        ::-1,
+                                                                        :])
         np.testing.assert_array_equal(lats, self.lats)
         np.testing.assert_array_equal(values, self.values)
-    
+
     def test_lons_shift_values(self):
         expected_vals = np.array([[2, 3, 0, 1],
                                   [6, 7, 4, 5],
@@ -121,7 +133,7 @@ class TestNormalizeLatLonValues(unittest.TestCase):
                                                             self.lons2,
                                                             self.values2)
         np.testing.assert_array_equal(values, expected_vals)
-        
+
     def test_shift_and_reversed(self):
         expected_vals = np.array([[10, 11, 8, 9],
                                   [6, 7, 4, 5],
@@ -130,20 +142,21 @@ class TestNormalizeLatLonValues(unittest.TestCase):
                                                             self.lons2,
                                                             self.values2)
         np.testing.assert_array_equal(values, expected_vals)
-        
+
     def test_lats_not_sorted(self):
-        self.assertRaises(ValueError, 
+        self.assertRaises(ValueError,
                           utils.normalize_lat_lon_values,
                           self.lats_unsorted,
                           self.lons2,
                           self.values2)
-                          
+
     def test_lons_not_sorted(self):
-        self.assertRaises(ValueError, 
+        self.assertRaises(ValueError,
                           utils.normalize_lat_lon_values,
                           self.lats2,
                           self.lons_unsorted,
                           self.values2)
+
 
 class TestReshapeMonthlyToAnnually(unittest.TestCase):
     ''' Testing function 'reshape_monthly_to_annually' from ocw.utils.py '''
@@ -151,11 +164,13 @@ class TestReshapeMonthlyToAnnually(unittest.TestCase):
     def setUp(self):
         self.lat = np.array([10, 12, 14, 16, 18])
         self.lon = np.array([100, 102, 104, 106, 108])
-        self.time = np.array([datetime.datetime(2000, 1, 1) + relativedelta(months = x) for x in range(24)])
+        self.time = np.array(
+            [datetime.datetime(2000, 1, 1) + relativedelta(months=x)
+             for x in range(24)])
         flat_array = np.array(range(600))
         self.value = flat_array.reshape(24, 5, 5)
         self.variable = 'prec'
-        self.test_dataset = Dataset(self.lat, self.lon, self.time, 
+        self.test_dataset = Dataset(self.lat, self.lon, self.time,
                                     self.value, self.variable)
 
     def test_reshape_full_year(self):
@@ -164,12 +179,17 @@ class TestReshapeMonthlyToAnnually(unittest.TestCase):
             utils.reshape_monthly_to_annually(self.test_dataset), new_values)
 
     def test_reshape_not_full_year(self):
-        new_time = np.array([datetime.datetime(2000, 1, 1) + relativedelta(months = x) for x in range(26)])
+        new_time = np.array(
+            [datetime.datetime(2000, 1, 1) + relativedelta(months=x)
+             for x in range(26)])
         flat_array = np.array(range(650))
         value = flat_array.reshape(26, 5, 5)
-        bad_dataset = Dataset(self.lat, self.lon, new_time, value, self.variable)
+        bad_dataset = Dataset(self.lat, self.lon,
+                              new_time, value, self.variable)
 
-        self.assertRaises(ValueError, utils.reshape_monthly_to_annually, bad_dataset)
+        self.assertRaises(
+            ValueError, utils.reshape_monthly_to_annually, bad_dataset)
+
 
 class TestCalcClimatologyYear(unittest.TestCase):
     ''' Testing function 'calc_climatology_year' from ocw.utils.py '''
@@ -177,7 +197,9 @@ class TestCalcClimatologyYear(unittest.TestCase):
     def setUp(self):
         self.lat = np.array([10, 12, 14, 16, 18])
         self.lon = np.array([100, 102, 104, 106, 108])
-        self.time = np.array([datetime.datetime(2000, 1, 1) + relativedelta(months = x) for x in range(24)])
+        self.time = np.array(
+            [datetime.datetime(2000, 1, 1) + relativedelta(months=x)
+             for x in range(24)])
         flat_array = np.array(range(600))
         self.value = flat_array.reshape(24, 5, 5)
         self.variable = 'prec'
@@ -185,7 +207,8 @@ class TestCalcClimatologyYear(unittest.TestCase):
                                     self.value, self.variable)
 
     def test_annually_mean(self):
-        annually_mean = np.append(np.arange(137.5, 162.5, 1), np.arange(437.5, 462.5, 1))
+        annually_mean = np.append(
+            np.arange(137.5, 162.5, 1), np.arange(437.5, 462.5, 1))
         annually_mean.shape = (2, 5, 5)
         np.testing.assert_array_equal(
             utils.calc_climatology_year(self.test_dataset)[0], annually_mean)
@@ -206,18 +229,22 @@ class TestCalcClimatologyMonthly(unittest.TestCase):
         start_date = datetime.datetime(2000, 1, 1)
         self.times = np.array([start_date + relativedelta(months=x)
                                for x in range(36)])
-        self.values = np.array([1]*300 + [2]*300 + [0]*300).reshape(36, 5, 5)
+        self.values = np.array([1] * 300 + [2] * 300 +
+                               [0] * 300).reshape(36, 5, 5)
         self.variable = 'testdata'
         self.dataset = Dataset(self.lats, self.lons, self.times,
                                self.values, self.variable)
 
     def test_calc_climatology_monthly(self):
         expected_result = np.ones(300).reshape(12, 5, 5)
-        expected_times = np.array([datetime.datetime(1, 1, 1) + relativedelta(months = x) 
+        expected_times = np.array([datetime.datetime(1, 1, 1) +
+                                   relativedelta(months=x)
                                    for x in range(12)])
-        actual_result, actual_times = utils.calc_climatology_monthly(self.dataset)
+        actual_result, actual_times = utils.calc_climatology_monthly(
+            self.dataset)
         np.testing.assert_array_equal(actual_result, expected_result)
         np.testing.assert_array_equal(actual_times, expected_times)
+
 
 class TestCalcTimeSeries(unittest.TestCase):
     ''' Tests the 'calc_time_series' method from ocw.utils.py '''
@@ -235,7 +262,8 @@ class TestCalcTimeSeries(unittest.TestCase):
 
     def test_calc_time_series(self):
         expected_result = np.ones(12)
-        np.testing.assert_array_equal(utils.calc_time_series(self.dataset), expected_result)
-        
+        np.testing.assert_array_equal(
+            utils.calc_time_series(self.dataset), expected_result)
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Following PEP8 violations are fixed

- Remove trailing whitespaces
- Fix lines with length > 79
- Add two blank lines after every function