### PR TITLE
CLIMATE-829 - Add conda package recipes

### DIFF
--- a/conda_recipes/bottle/bld.bat
+++ b/conda_recipes/bottle/bld.bat
@@ -1,0 +1,8 @@
+"%PYTHON%" setup.py install
+if errorlevel 1 exit 1
+
+:: Add more build steps here, if they are necessary.
+
+:: See
+:: http://docs.continuum.io/conda/build.html
+:: for a list of environment variables that are set during the build process.

--- a/conda_recipes/bottle/build.sh
+++ b/conda_recipes/bottle/build.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+$PYTHON setup.py install
+
+# Add more build steps here, if they are necessary.
+
+# See
+# http://docs.continuum.io/conda/build.html
+# for a list of environment variables that are set during the build process.

--- a/conda_recipes/bottle/meta.yaml
+++ b/conda_recipes/bottle/meta.yaml
@@ -1,0 +1,59 @@
+package:
+  name: bottle
+  version: "0.12.9"
+
+source:
+  fn: bottle-0.12.9.tar.gz
+  url: https://files.pythonhosted.org/packages/d2/59/e61e3dc47ed47d34f9813be6d65462acaaba9c6c50ec863db74101fa8757/bottle-0.12.9.tar.gz
+  md5: f5850258a86224a791171e8ecbb66d99
+#  patches:
+   # List any patch files here
+   # - fix.patch
+
+# build:
+  # noarch_python: True
+  # preserve_egg_dir: True
+  # entry_points:
+    # Put any entry points (scripts to be generated automatically) here. The
+    # syntax is module:function.  For example
+    #
+    # - bottle = bottle:main
+    #
+    # Would create an entry point called bottle that calls bottle.main()
+
+
+  # If this is a new build for the same version, increment the build
+  # number. If you do not include this key, it defaults to 0.
+  # number: 1
+
+requirements:
+  build:
+    - python
+
+  run:
+    - python
+
+# test:
+  # Python imports
+  # imports:
+
+  # commands:
+    # You can put test commands to be run here.  Use this to test that the
+    # entry points work.
+
+
+  # You can also put a file called run_test.py in the recipe that will be run
+  # at test time.
+
+  # requires:
+    # Put any additional test requirements here.  For example
+    # - nose
+
+about:
+  home: http://bottlepy.org/
+  license: MIT License
+  summary: 'Fast and simple WSGI-framework for small web-applications.'
+
+# See
+# http://docs.continuum.io/conda/build.html for
+# more information about meta.yaml

--- a/conda_recipes/esgf-pyclient/bld.bat
+++ b/conda_recipes/esgf-pyclient/bld.bat
@@ -1,0 +1,8 @@
+"%PYTHON%" setup.py install
+if errorlevel 1 exit 1
+
+:: Add more build steps here, if they are necessary.
+
+:: See
+:: http://docs.continuum.io/conda/build.html
+:: for a list of environment variables that are set during the build process.

--- a/conda_recipes/esgf-pyclient/build.sh
+++ b/conda_recipes/esgf-pyclient/build.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+$PYTHON setup.py install
+
+# Add more build steps here, if they are necessary.
+
+# See
+# http://docs.continuum.io/conda/build.html
+# for a list of environment variables that are set during the build process.

--- a/conda_recipes/esgf-pyclient/meta.yaml
+++ b/conda_recipes/esgf-pyclient/meta.yaml
@@ -1,0 +1,65 @@
+package:
+  name: esgf-pyclient
+  version: "0.1.6"
+
+source:
+  fn: esgf-pyclient-0.1.6.tar.gz
+  url: https://files.pythonhosted.org/packages/2b/9d/16ffd2c1b2d30ee350e55a23168395659366903da05c413db24ee1b374e1/esgf-pyclient-0.1.6.tar.gz
+  md5: 228ac9d7e3a600f587c7cb46c7389cdc
+#  patches:
+   # List any patch files here
+   # - fix.patch
+
+# build:
+  # noarch_python: True
+  # preserve_egg_dir: True
+  # entry_points:
+    # Put any entry points (scripts to be generated automatically) here. The
+    # syntax is module:function.  For example
+    #
+    # - esgf-pyclient = esgf-pyclient:main
+    #
+    # Would create an entry point called esgf-pyclient that calls esgf-pyclient.main()
+
+
+  # If this is a new build for the same version, increment the build
+  # number. If you do not include this key, it defaults to 0.
+  # number: 1
+
+requirements:
+  build:
+    - python
+    - setuptools
+    - jinja2
+
+  run:
+    - python
+    - jinja2
+
+test:
+  # Python imports
+  imports:
+    - pyesgf
+    - pyesgf.search
+    - pyesgf.security
+
+  # commands:
+    # You can put test commands to be run here.  Use this to test that the
+    # entry points work.
+
+
+  # You can also put a file called run_test.py in the recipe that will be run
+  # at test time.
+
+  # requires:
+    # Put any additional test requirements here.  For example
+    # - nose
+
+about:
+  home: http://esgf-pyclient.readthedocs.org
+  license: BSD License
+  summary: 'A library interacting with ESGF services within Python'
+
+# See
+# http://docs.continuum.io/conda/build.html for
+# more information about meta.yaml

--- a/conda_recipes/myproxyclient/bld.bat
+++ b/conda_recipes/myproxyclient/bld.bat
@@ -1,0 +1,8 @@
+"%PYTHON%" setup.py install
+if errorlevel 1 exit 1
+
+:: Add more build steps here, if they are necessary.
+
+:: See
+:: http://docs.continuum.io/conda/build.html
+:: for a list of environment variables that are set during the build process.

--- a/conda_recipes/myproxyclient/build.sh
+++ b/conda_recipes/myproxyclient/build.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+$PYTHON setup.py install
+
+# Add more build steps here, if they are necessary.
+
+# See
+# http://docs.continuum.io/conda/build.html
+# for a list of environment variables that are set during the build process.

--- a/conda_recipes/myproxyclient/meta.yaml
+++ b/conda_recipes/myproxyclient/meta.yaml
@@ -1,0 +1,67 @@
+package:
+  name: myproxyclient
+  version: "1.4.3"
+
+source:
+  fn: MyProxyClient-1.4.3.tar.gz
+  url: https://files.pythonhosted.org/packages/87/40/c461e690422a1c6994630d5f73d74295037793eb5e41f346a7b55b6d5baa/MyProxyClient-1.4.3.tar.gz
+  md5: 15d1dccae2cde5d24cd8fb082972debc
+#  patches:
+   # List any patch files here
+   # - fix.patch
+
+build:
+  # noarch_python: True
+  # preserve_egg_dir: True
+  entry_points:
+    # Put any entry points (scripts to be generated automatically) here. The
+    # syntax is module:function.  For example
+    #
+    # - myproxyclient = myproxyclient:main
+    #
+    # Would create an entry point called myproxyclient that calls myproxyclient.main()
+
+    - myproxyclient = myproxy.script:main
+
+  # If this is a new build for the same version, increment the build
+  # number. If you do not include this key, it defaults to 0.
+  # number: 1
+
+requirements:
+  build:
+    - python
+    - setuptools
+    - pyopenssl
+
+  run:
+    - python
+    - pyopenssl
+
+test:
+  # Python imports
+  imports:
+    - myproxy
+    - myproxy.test
+    - myproxy.utils
+
+  commands:
+    # You can put test commands to be run here.  Use this to test that the
+    # entry points work.
+
+    - myproxyclient --help
+
+  # You can also put a file called run_test.py in the recipe that will be run
+  # at test time.
+
+  # requires:
+    # Put any additional test requirements here.  For example
+    # - nose
+
+about:
+  home: https://github.com/cedadev/MyProxyClient
+  license: GNU Library or Lesser General Public License (BSD)
+  summary: 'MyProxy Client'
+
+# See
+# http://docs.continuum.io/conda/build.html for
+# more information about meta.yaml

--- a/conda_recipes/ocw/bld.bat
+++ b/conda_recipes/ocw/bld.bat
@@ -1,0 +1,8 @@
+"%PYTHON%" setup.py install
+if errorlevel 1 exit 1
+
+:: Add more build steps here, if they are necessary.
+
+:: See
+:: http://docs.continuum.io/conda/build.html
+:: for a list of environment variables that are set during the build process.

--- a/conda_recipes/ocw/build.sh
+++ b/conda_recipes/ocw/build.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+$PYTHON setup.py install
+
+# Add more build steps here, if they are necessary.
+
+# See
+# http://docs.continuum.io/conda/build.html
+# for a list of environment variables that are set during the build process.

--- a/conda_recipes/ocw/meta.yaml
+++ b/conda_recipes/ocw/meta.yaml
@@ -1,0 +1,43 @@
+package:
+  name: ocw
+  version: 1.1.0
+
+source:
+  git_url: https://github.com/apache/climate.git
+  # git_rev: 1.1.0
+
+build:
+  number: 0
+
+requirements:
+  build:
+    - python
+    - setuptools
+
+  run:
+    - python
+    - numpy
+    - scipy
+    - matplotlib
+    - basemap
+    - netcdf4
+    - h5py
+    - bottle
+    - pydap
+    - python-dateutil
+    - mock
+    - myproxyclient
+    - webtest
+    - esgf-pyclient
+
+test:
+  # Python imports
+  imports:
+    - ocw
+    - ocw.data_source
+    - ocw.esgf
+
+about:
+  home: http://climate.apache.org/
+  license: Apache License
+  summary: 'A library for simplifying the process of climate model evaluation.'

--- a/conda_recipes/pydap/bld.bat
+++ b/conda_recipes/pydap/bld.bat
@@ -1,0 +1,8 @@
+"%PYTHON%" setup.py install
+if errorlevel 1 exit 1
+
+:: Add more build steps here, if they are necessary.
+
+:: See
+:: http://docs.continuum.io/conda/build.html
+:: for a list of environment variables that are set during the build process.

--- a/conda_recipes/pydap/build.sh
+++ b/conda_recipes/pydap/build.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+$PYTHON setup.py install
+
+# Add more build steps here, if they are necessary.
+
+# See
+# http://docs.continuum.io/conda/build.html
+# for a list of environment variables that are set during the build process.

--- a/conda_recipes/pydap/meta.yaml
+++ b/conda_recipes/pydap/meta.yaml
@@ -1,0 +1,64 @@
+package:
+  name: pydap
+  version: "3.1.1"
+
+source:
+  fn: Pydap-3.1.1.tar.gz
+  url: https://files.pythonhosted.org/packages/cd/da/577a2b6721e9b103f1671bd020f5553e582f2c509fe5cade636822b35351/Pydap-3.1.1.tar.gz
+  md5: d13630328c121eeeb0e0f015eb9e7124
+#  patches:
+   # List any patch files here
+   # - fix.patch
+
+build:
+  # noarch_python: True
+  preserve_egg_dir: True
+  # entry_points:
+    # Put any entry points (scripts to be generated automatically) here. The
+    # syntax is module:function.  For example
+    #
+    # - pydap = pydap:main
+    #
+    # Would create an entry point called pydap that calls pydap.main()
+
+
+  # If this is a new build for the same version, increment the build
+  # number. If you do not include this key, it defaults to 0.
+  # number: 1
+
+requirements:
+  build:
+    - python
+    - setuptools
+
+  run:
+    - python
+    - setuptools
+
+test:
+  # Python imports
+  imports:
+    - paste
+    - paste.deploy
+
+  # commands:
+    # You can put test commands to be run here.  Use this to test that the
+    # entry points work.
+
+
+  # You can also put a file called run_test.py in the recipe that will be run
+  # at test time.
+
+  requires:
+    - nose >=0.11
+    # Put any additional test requirements here.  For example
+    # - nose
+
+about:
+  home: http://pythonpaste.org/deploy/
+  license: MIT License
+  summary: 'Load, configure, and compose WSGI applications and servers'
+
+# See
+# http://docs.continuum.io/conda/build.html for
+# more information about meta.yaml

--- a/conda_recipes/sphinxcontrib-httpdomain/bld.bat
+++ b/conda_recipes/sphinxcontrib-httpdomain/bld.bat
@@ -1,0 +1,8 @@
+"%PYTHON%" setup.py install
+if errorlevel 1 exit 1
+
+:: Add more build steps here, if they are necessary.
+
+:: See
+:: http://docs.continuum.io/conda/build.html
+:: for a list of environment variables that are set during the build process.

--- a/conda_recipes/sphinxcontrib-httpdomain/build.sh
+++ b/conda_recipes/sphinxcontrib-httpdomain/build.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+$PYTHON setup.py install
+
+# Add more build steps here, if they are necessary.
+
+# See
+# http://docs.continuum.io/conda/build.html
+# for a list of environment variables that are set during the build process.

--- a/conda_recipes/sphinxcontrib-httpdomain/meta.yaml
+++ b/conda_recipes/sphinxcontrib-httpdomain/meta.yaml
@@ -1,0 +1,66 @@
+package:
+  name: sphinxcontrib-httpdomain
+  version: "1.5.0"
+
+source:
+  fn: sphinxcontrib-httpdomain-1.5.0.tar.gz
+  url: https://files.pythonhosted.org/packages/a5/52/0ded71896b9d25621b44d681cdd352c37a9ed81219a6b62014bd15dd2b9e/sphinxcontrib-httpdomain-1.5.0.tar.gz
+  md5: db069391a08c0f0bd6aa6819f5018337
+#  patches:
+   # List any patch files here
+   # - fix.patch
+
+# build:
+  # noarch_python: True
+  # preserve_egg_dir: True
+  # entry_points:
+    # Put any entry points (scripts to be generated automatically) here. The
+    # syntax is module:function.  For example
+    #
+    # - sphinxcontrib-httpdomain = sphinxcontrib-httpdomain:main
+    #
+    # Would create an entry point called sphinxcontrib-httpdomain that calls sphinxcontrib-httpdomain.main()
+
+
+  # If this is a new build for the same version, increment the build
+  # number. If you do not include this key, it defaults to 0.
+  # number: 1
+
+requirements:
+  build:
+    - python
+    - setuptools
+    - sphinx >=1.0
+    - six
+
+  run:
+    - python
+    - sphinx >=1.0
+    - six
+
+test:
+  # Python imports
+  imports:
+    - sphinxcontrib
+    - sphinxcontrib.autohttp
+
+  # commands:
+    # You can put test commands to be run here.  Use this to test that the
+    # entry points work.
+
+
+  # You can also put a file called run_test.py in the recipe that will be run
+  # at test time.
+
+  # requires:
+    # Put any additional test requirements here.  For example
+    # - nose
+
+about:
+  home: https://bitbucket.org/birkenfeld/sphinx-contrib/src/default/httpdomain/
+  license: BSD License
+  summary: 'Sphinx domain for HTTP APIs'
+
+# See
+# http://docs.continuum.io/conda/build.html for
+# more information about meta.yaml


### PR DESCRIPTION
This commit includes conda package recipes for ocw as well as some specific dependencies which do not currently have packages on the main anaconda channel. Note that any attempt building the package from the recipe as is will install the most recently committed code, but this can be changed by setting `git_rev` to a specific release version in `ocw/meta.yaml`.