### PR TITLE
CLIMATE-830 Broken tests in dap.py

### DIFF
--- a/ocw/tests/test_dap.py
+++ b/ocw/tests/test_dap.py
@@ -30,6 +30,15 @@ class TestDap(unittest.TestCase):
         cls.name = 'foo'
         cls.dataset = dap.load(cls.url, 'CGusfc', name=cls.name)
 
+        # The tests fail for this dataset since the dataset does not have a time(1D) variable.
+        # The tests fail because dap.py assumes that the openDAP datasets necessarily have the 
+        # three variables 1D variables lat, lon and time and the lines 53,54 and 55 are written
+        # on the same assumption.   
+        cls.url2 = 'http://opendap-uat.jpl.nasa.gov/opendap/GeodeticsGravity/'\
+                   'tellus/L3/mascon/RL05/JPL/CRI/netcdf/CLM4.SCALE_FACTOR.JPL.MSCNv01CRIv01.nc'
+        cls.name2 = 'foo2'
+        cls.dataset2 = dap.load(cls.url2, 'scale_factor', name=cls.name)
+
     def test_dataset_is_returned(self):
         self.assertTrue(isinstance(self.dataset, Dataset))
 


### PR DESCRIPTION
- The tests fail because the dataset that I have used for testing does not contain time variable in it.
- The dap.py runs on a presumption that the dataset must contain the three variables time, lat and lon necessarily.  