### PR TITLE
CLIMATE-830 Reverting the broken test case in test_dap.py

### DIFF
--- a/ocw/tests/test_dap.py
+++ b/ocw/tests/test_dap.py
@@ -30,6 +30,7 @@ class TestDap(unittest.TestCase):
         cls.name = 'foo'
         cls.dataset = dap.load(cls.url, 'CGusfc', name=cls.name)
 
+        '''
         # The tests fail for this dataset since the dataset does not have a time(1D) variable.
         # The tests fail because dap.py assumes that the openDAP datasets necessarily have the 
         # three variables 1D variables lat, lon and time and the lines 53,54 and 55 are written
@@ -37,7 +38,7 @@ class TestDap(unittest.TestCase):
         cls.url2 = 'http://opendap-uat.jpl.nasa.gov/opendap/GeodeticsGravity/'\
                    'tellus/L3/mascon/RL05/JPL/CRI/netcdf/CLM4.SCALE_FACTOR.JPL.MSCNv01CRIv01.nc'
         cls.name2 = 'foo2'
-        cls.dataset2 = dap.load(cls.url2, 'scale_factor', name=cls.name)
+        cls.dataset2 = dap.load(cls.url2, 'scale_factor', name=cls.name)'''
 
     def test_dataset_is_returned(self):
         self.assertTrue(isinstance(self.dataset, Dataset))


### PR DESCRIPTION
- This PR comments the failing test case in test_dap.py as suggested by @lewismc.
- We can comment it out once we find a good fix. 

@jarifibrahim you are good to go with this now. Thanks. 