### PR TITLE
CLIMATE-882 - local data source is not Python 3 compatible

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -44,9 +44,6 @@ install:
   # Add conda-forge to search so all dependencies can be resolved
   - conda config --add channels conda-forge
   - conda create -q -n test-environment nose python=$TRAVIS_PYTHON_VERSION --file $DEPS
-
-  # Need this to exclude pydap test for python 3
-  - pip install nose-exclude
   
   # Install ocw
   - source activate test-environment

--- a/ocw/data_source/local.py
+++ b/ocw/data_source/local.py
@@ -31,9 +31,9 @@ import h5py
 import numpy
 import numpy.ma as ma
 
-LAT_NAMES = ['y', 'rlat', 'rlats', 'lat', 'lats', 'latitude', 'latitudes']
-LON_NAMES = ['x', 'rlon', 'rlons', 'lon', 'lons', 'longitude', 'longitudes']
-TIME_NAMES = ['time', 'times', 'date', 'dates', 'julian']
+LAT_NAMES = [b'y', b'rlat', b'rlats', b'lat', b'lats', b'latitude', b'latitudes']
+LON_NAMES = [b'x', b'rlon', b'rlons', b'lon', b'lons', b'longitude', b'longitudes']
+TIME_NAMES = [b'time', b'times', b'date', b'dates', b'julian']
 
 
 def _get_netcdf_variable_name(valid_var_names, netcdf, netcdf_var):
@@ -78,7 +78,7 @@ def _get_netcdf_variable_name(valid_var_names, netcdf, netcdf_var):
         # earlier. If the dimension's name matches then that variable is
         # potentially what we want to return to the user.
         possible_vars = []
-        for var in netcdf.variables.keys():
+        for var in list(netcdf.variables.keys()):
             var_dimensions = netcdf.variables[var].dimensions
 
             # Skip any dimensions are > 1D
@@ -96,7 +96,7 @@ def _get_netcdf_variable_name(valid_var_names, netcdf, netcdf_var):
             return possible_vars[0]
 
     # Check for valid variable names in netCDF variable names
-    variables = netcdf.variables.keys()
+    variables = list(netcdf.variables.keys())
     vars_lower = [var.encode().lower() for var in variables]
 
     intersect = set(valid_var_names).intersection(vars_lower)

--- a/test.sh
+++ b/test.sh
@@ -26,10 +26,11 @@ echo ""
 cp .noserc $HOME/.noserc
 
 # Exclude dap tests if using python 3
+NOSE_FLAGS=''
 if [[ "$1" != "2.7" ]]; then
-  export NOSE_EXCLUDE_TESTS=ocw.tests.test_dap.TestDap
+  NOSE_FLAGS='-I test_dap'
 fi
 
 echo "---------------- Running Unit Tests ---------------"
-nosetests
+nosetests $NOSE_FLAGS
 echo "---------------- All Tests successfully completed ---------------"


### PR DESCRIPTION
With this PR, the main python 3 incompatibility issue in `local.py` is fixed and we can now successfully finish the smoke tests on python 3. This will now let us see precisely which parts of the ocw codebase are not python 3 compatible with each of our CI builds.