### PR TITLE
[CLIMATE-847] Support multiple observation / reference datasets in run_RCMES.py

### DIFF
--- a/RCMES/configuration_files/CMIP5_precipitation_evaluation.yaml
+++ b/RCMES/configuration_files/CMIP5_precipitation_evaluation.yaml
@@ -10,7 +10,7 @@ time:
     temporal_resolution: monthly
     month_start: 1
     month_end: 12
-    average_each_year: Yes  
+    average_each_year: Yes
 
 space:
     boundary_type: CORDEX Central America
@@ -21,16 +21,14 @@ regrid:
     regrid_dlon: 0.44
 
 datasets:
-    reference:
-        - loader_name: rcmed
-          name: TRMM
-          dataset_id: 3
-          parameter_id: 36
+  - loader_name: rcmed
+    name: TRMM
+    dataset_id: 3
+    parameter_id: 36
 
-    targets:
-        - loader_name: local
-          file_path: ./data/CMIP5/prec/CMIP5_*prec.nc
-          variable_name: prec
+  - loader_name: local
+    file_path: ./data/CMIP5/prec/CMIP5_*prec.nc
+    variable_name: prec
 
 number_of_metrics_and_plots: 1
 

--- a/RCMES/configuration_files/CORDEX-Africa_examples/Fig10a_cru.yaml
+++ b/RCMES/configuration_files/CORDEX-Africa_examples/Fig10a_cru.yaml
@@ -24,19 +24,17 @@ regrid:
     regrid_dlon: 0.44
 
 datasets:
-    reference:
-        - loader_name: rcmed
-          name: CRU
-          dataset_id: 10
-          parameter_id: 42
-          multiplying_factor: 0.01
+  - loader_name: rcmed
+    name: CRU
+    dataset_id: 10
+    parameter_id: 42
+    multiplying_factor: 0.01
 
-    targets:
-        - loader_name: local
-          file_path: ./data/CORDEX-Africa_data/AFRICA*clt.nc
-          variable_name: clt
-          lat_name: lat
-          lon_name: lon
+  - loader_name: local
+    file_path: ./data/CORDEX-Africa_data/AFRICA*clt.nc
+    variable_name: clt
+    lat_name: lat
+    lon_name: lon
 
 number_of_metrics_and_plots: 1
 

--- a/RCMES/configuration_files/CORDEX-Africa_examples/Fig10b_cru.yaml
+++ b/RCMES/configuration_files/CORDEX-Africa_examples/Fig10b_cru.yaml
@@ -24,16 +24,14 @@ regrid:
     regrid_dlon: 0.44
 
 datasets:
-    reference:
-        - loader_name: rcmed
-          name: CRU
-          dataset_id: 10
-          parameter_id: 37
+  - loader_name: rcmed
+    name: CRU
+    dataset_id: 10
+    parameter_id: 37
 
-    targets:
-        - loader_name: local
-          file_path: ./data/CORDEX-Africa_data/AFRICA*pr.nc
-          variable_name: pr
+  - loader_name: local
+    file_path: ./data/CORDEX-Africa_data/AFRICA*pr.nc
+    variable_name: pr
 
 number_of_metrics_and_plots: 1
 

--- a/RCMES/configuration_files/CORDEX-Africa_examples/Fig1_2_4a_5.yaml
+++ b/RCMES/configuration_files/CORDEX-Africa_examples/Fig1_2_4a_5.yaml
@@ -24,16 +24,14 @@ regrid:
     regrid_dlon: 0.44
 
 datasets:
-    reference:
-        - loader_name: rcmed
-          name: CRU
-          dataset_id: 10
-          parameter_id: 37
-
-    targets:
-        - loader_name: local
-          file_path: ./data/CORDEX-Africa_data/AFRICA*pr.nc
-          variable_name: pr
+  - loader_name: rcmed
+    name: CRU
+    dataset_id: 10
+    parameter_id: 37
+    
+  - loader_name: local
+    file_path: ./data/CORDEX-Africa_data/AFRICA*pr.nc
+    variable_name: pr
 
 number_of_metrics_and_plots: 4
 

--- a/RCMES/configuration_files/CORDEX-Africa_examples/Fig3a_summer.yaml
+++ b/RCMES/configuration_files/CORDEX-Africa_examples/Fig3a_summer.yaml
@@ -24,16 +24,14 @@ regrid:
     regrid_dlon: 0.44
 
 datasets:
-    reference:
-        - loader_name: rcmed
-          name: CRU
-          dataset_id: 10
-          parameter_id: 37
+  - loader_name: rcmed
+    name: CRU
+    dataset_id: 10
+    parameter_id: 37
 
-    targets:
-        - loader_name: local
-          file_path: ./data/CORDEX-Africa_data/AFRICA*pr.nc
-          variable_name: pr    
+  - loader_name: local
+    file_path: ./data/CORDEX-Africa_data/AFRICA*pr.nc
+    variable_name: pr
 
 number_of_metrics_and_plots: 1
 

--- a/RCMES/configuration_files/CORDEX-Africa_examples/Fig3a_winter.yaml
+++ b/RCMES/configuration_files/CORDEX-Africa_examples/Fig3a_winter.yaml
@@ -24,16 +24,14 @@ regrid:
     regrid_dlon: 0.44
 
 datasets:
-    reference:
-        - loader_name: rcmed
-          name: CRU
-          dataset_id: 10
-          parameter_id: 37
+  - loader_name: rcmed
+    name: CRU
+    dataset_id: 10
+    parameter_id: 37
 
-    targets:
-        - loader_name: local
-          file_path: ./data/CORDEX-Africa_data/AFRICA*pr.nc
-          variable_name: pr    
+  - loader_name: local
+    file_path: ./data/CORDEX-Africa_data/AFRICA*pr.nc
+    variable_name: pr
 
 number_of_metrics_and_plots: 1
 

--- a/RCMES/configuration_files/CORDEX-Africa_examples/Fig3b_summer.yaml
+++ b/RCMES/configuration_files/CORDEX-Africa_examples/Fig3b_summer.yaml
@@ -24,16 +24,14 @@ regrid:
     regrid_dlon: 0.44
 
 datasets:
-    reference:
-        - loader_name: rcmed
-          name: CRU
-          dataset_id: 10
-          parameter_id: 38
+  - loader_name: rcmed
+    name: CRU
+    dataset_id: 10
+    parameter_id: 38
 
-    targets:
-        - loader_name: local
-          file_path: ./data/CORDEX-Africa_data/AFRICA*tas.nc
-          variable_name: tas    
+  - loader_name: local
+    file_path: ./data/CORDEX-Africa_data/AFRICA*tas.nc
+    variable_name: tas
 
 number_of_metrics_and_plots: 1
 

--- a/RCMES/configuration_files/CORDEX-Africa_examples/Fig3b_winter.yaml
+++ b/RCMES/configuration_files/CORDEX-Africa_examples/Fig3b_winter.yaml
@@ -24,16 +24,14 @@ regrid:
     regrid_dlon: 0.44
 
 datasets:
-    reference:
-        - loader_name: rcmed
-          name: CRU
-          dataset_id: 10
-          parameter_id: 38
+  - loader_name: rcmed
+    name: CRU
+    dataset_id: 10
+    parameter_id: 38
 
-    targets:
-        - loader_name: local
-          file_path: ./data/CORDEX-Africa_data/AFRICA*tas.nc
-          variable_name: tas    
+  - loader_name: local
+    file_path: ./data/CORDEX-Africa_data/AFRICA*tas.nc
+    variable_name: tas
 
 number_of_metrics_and_plots: 1
 

--- a/RCMES/configuration_files/CORDEX-Africa_examples/Fig4d_7d_8ad.yaml
+++ b/RCMES/configuration_files/CORDEX-Africa_examples/Fig4d_7d_8ad.yaml
@@ -24,16 +24,14 @@ regrid:
     regrid_dlon: 0.44
 
 datasets:
-    reference:
-        - loader_name: rcmed
-          name: CRU
-          dataset_id: 10
-          parameter_id: 38
+  - loader_name: rcmed
+    name: CRU
+    dataset_id: 10
+    parameter_id: 38
 
-    targets:
-        - loader_name: local
-          file_path: ./data/CORDEX-Africa_data/AFRICA*tas.nc
-          variable_name: tas    
+  - loader_name: local
+    file_path: ./data/CORDEX-Africa_data/AFRICA*tas.nc
+    variable_name: tas
 
 number_of_metrics_and_plots: 3
 

--- a/RCMES/configuration_files/CORDEX-Africa_examples/Fig4f_9bcd.yaml
+++ b/RCMES/configuration_files/CORDEX-Africa_examples/Fig4f_9bcd.yaml
@@ -24,19 +24,17 @@ regrid:
     regrid_dlon: 0.44
 
 datasets:
-    reference:
-        - loader_name: rcmed
-          name: CRU
-          dataset_id: 10
-          parameter_id: 42
-          multiplying_factor: 0.01
+  - loader_name: rcmed
+    name: CRU
+    dataset_id: 10
+    parameter_id: 42
+    multiplying_factor: 0.01
 
-    targets:
-        - loader_name: local
-          file_path: ./data/CORDEX-Africa_data/AFRICA*clt.nc
-          variable_name: clt
-          lat_name: lat
-          lon_name: lon
+  - loader_name: local
+    file_path: ./data/CORDEX-Africa_data/AFRICA*clt.nc
+    variable_name: clt
+    lat_name: lat
+    lon_name: lon
 
 number_of_metrics_and_plots: 3
 

--- a/RCMES/configuration_files/CORDEX-Africa_examples/Fig7e_8be.yaml
+++ b/RCMES/configuration_files/CORDEX-Africa_examples/Fig7e_8be.yaml
@@ -24,16 +24,14 @@ regrid:
     regrid_dlon: 0.44
 
 datasets:
-    reference:
-        - loader_name: rcmed
-          name: CRU
-          dataset_id: 10
-          parameter_id: 39
+  - loader_name: rcmed
+    name: CRU
+    dataset_id: 10
+    parameter_id: 39
 
-    targets:
-        - loader_name: local
-          file_path: ./data/CORDEX-Africa_data/AFRICA*tasmax.nc
-          variable_name: tasmax    
+  - loader_name: local
+    file_path: ./data/CORDEX-Africa_data/AFRICA*tasmax.nc
+    variable_name: tasmax
 
 number_of_metrics_and_plots: 2
 

--- a/RCMES/configuration_files/CORDEX-Africa_examples/Fig7f_8cf.yaml
+++ b/RCMES/configuration_files/CORDEX-Africa_examples/Fig7f_8cf.yaml
@@ -24,18 +24,16 @@ regrid:
     regrid_dlon: 0.44
 
 datasets:
-    reference:
-        - loader_name: rcmed
-          name: CRU
-          dataset_id: 10
-          parameter_id: 41
+  - loader_name: rcmed
+    name: CRU
+    dataset_id: 10
+    parameter_id: 41
 
-    targets:
-        - loader_name: local
-          file_path: ./data/CORDEX-Africa_data/AFRICA*tasmin.nc
-          variable_name: tasmin
-          lat_name: lat
-          lon_name: lon
+  - loader_name: local
+    file_path: ./data/CORDEX-Africa_data/AFRICA*tasmin.nc
+    variable_name: tasmin
+    lat_name: lat
+    lon_name: lon
 
 number_of_metrics_and_plots: 2
 

--- a/RCMES/configuration_files/CORDEX-Arctic_examples/cordex-arctic_cloud_fraction_bias_to_SRB.yaml
+++ b/RCMES/configuration_files/CORDEX-Arctic_examples/cordex-arctic_cloud_fraction_bias_to_SRB.yaml
@@ -40,17 +40,15 @@ regrid:
     regrid_dlon: 0.44
 
 datasets:
-    reference:
-        - loader_name: local
-          dataset_name: SRB
-          file_path: ./data/CORDEX-Arctic_data/srb_rel3.0_shortwave_from_1983_to_2007.nc
-          variable_name: cld_frac
-          multiplying_factor: 100.0
+  - loader_name: local
+    name: SRB
+    file_path: ./data/CORDEX-Arctic_data/srb_rel3.0_shortwave_from_1983_to_2007.nc
+    variable_name: cld_frac
+    multiplying_factor: 100.0
 
-    targets:
-        - loader_name: local
-          file_path: ./data/CORDEX-Arctic_data/clt*.nc
-          variable_name: clt     
+  - loader_name: local
+    file_path: ./data/CORDEX-Arctic_data/clt*.nc
+    variable_name: clt
 
 number_of_metrics_and_plots: 1
 

--- a/RCMES/configuration_files/CORDEX-Arctic_examples/cordex-arctic_rlds_bias_to_SRB.yaml
+++ b/RCMES/configuration_files/CORDEX-Arctic_examples/cordex-arctic_rlds_bias_to_SRB.yaml
@@ -40,17 +40,15 @@ regrid:
     regrid_dlon: 0.44
 
 datasets:
-    reference:
-        - loader_name: local
-          dataset_name: SRB
-          file_path: ./data/CORDEX-Arctic_data/srb_rel3.0_longwave_from_1983_to_2007.nc
-          variable_name: lw_sfc_dn
-          multiplying_factor: 1
+  - loader_name: local
+    name: SRB
+    file_path: ./data/CORDEX-Arctic_data/srb_rel3.0_longwave_from_1983_to_2007.nc
+    variable_name: lw_sfc_dn
+    multiplying_factor: 1
 
-    targets:
-        - loader_name: local
-          file_path: ./data/CORDEX-Arctic_data/rlds*.nc
-          variable_name: rlds
+  - loader_name: local
+    file_path: ./data/CORDEX-Arctic_data/rlds*.nc
+    variable_name: rlds
 
 number_of_metrics_and_plots: 1
 

--- a/RCMES/configuration_files/CORDEX-Arctic_examples/cordex-arctic_rlus_bias_to_SRB.yaml
+++ b/RCMES/configuration_files/CORDEX-Arctic_examples/cordex-arctic_rlus_bias_to_SRB.yaml
@@ -40,17 +40,15 @@ regrid:
     regrid_dlon: 0.44
 
 datasets:
-    reference:
-        - loader_name: local
-          dataset_name: SRB
-          file_path: ./data/CORDEX-Arctic_data/srb_rel3.0_longwave_from_1983_to_2007.nc
-          variable_name: lw_sfc_up
-          multiplying_factor: 1
+  - loader_name: local
+    name: SRB
+    file_path: ./data/CORDEX-Arctic_data/srb_rel3.0_longwave_from_1983_to_2007.nc
+    variable_name: lw_sfc_up
+    multiplying_factor: 1
 
-    targets:
-        - loader_name: local
-          file_path: ./data/CORDEX-Arctic_data/rlus*.nc
-          variable_name: rlus    
+  - loader_name: local
+    file_path: ./data/CORDEX-Arctic_data/rlus*.nc
+    variable_name: rlus
 
 number_of_metrics_and_plots: 1
 

--- a/RCMES/configuration_files/CORDEX-Arctic_examples/cordex-arctic_rsds_bias_to_SRB.yaml
+++ b/RCMES/configuration_files/CORDEX-Arctic_examples/cordex-arctic_rsds_bias_to_SRB.yaml
@@ -40,17 +40,15 @@ regrid:
     regrid_dlon: 0.44
 
 datasets:
-    reference:
-        - loader_name: local
-          dataset_name: SRB
-          file_path: ./data/CORDEX-Arctic_data/srb_rel3.0_shortwave_from_1983_to_2007.nc
-          variable_name: sw_sfc_dn
-          multiplying_factor: 1
+  - loader_name: local
+    name: SRB
+    file_path: ./data/CORDEX-Arctic_data/srb_rel3.0_shortwave_from_1983_to_2007.nc
+    variable_name: sw_sfc_dn
+    multiplying_factor: 1
 
-    targets:
-        - loader_name: local
-          file_path: ./data/CORDEX-Arctic_data/rsds*.nc
-          variable_name: rsds    
+  - loader_name: local
+    file_path: ./data/CORDEX-Arctic_data/rsds*.nc
+    variable_name: rsds
 
 number_of_metrics_and_plots: 1
 

--- a/RCMES/configuration_files/ESGF_example/ESGF-Example.yaml
+++ b/RCMES/configuration_files/ESGF_example/ESGF-Example.yaml
@@ -36,20 +36,18 @@ regrid:
     regrid_on_reference: True
     regrid_dlat: 0.50
     regrid_dlon: 0.50
+    boundary_check: False
 
 datasets:
-    reference:
-        - loader_name: esgf
-          name: AVISO
-          dataset_id: obs4MIPs.CNES.AVISO.zos.mon.v20110829|esgf-data.jpl.nasa.gov
-          variable_name: zos
+  - loader_name: esgf
+    name: AVISO
+    dataset_id: obs4MIPs.CNES.AVISO.zos.mon.v20110829|esgf-data.jpl.nasa.gov
+    variable_name: zos
 
-    targets:
-        - loader_name: esgf
-          name: MPI-ESM
-          dataset_id: cmip5.output1.MPI-M.MPI-ESM-LR.decadal1994.mon.ocean.Omon.r1i1p1.v20120529|esgf1.dkrz.de
-          variable_name: zos
-          boundary_check: False
+  - loader_name: esgf
+    name: MPI-ESM
+    dataset_id: cmip5.output1.MPI-M.MPI-ESM-LR.decadal1994.mon.ocean.Omon.r1i1p1.v20120529|esgf1.dkrz.de
+    variable_name: zos
 
 number_of_metrics_and_plots: 1
 

--- a/RCMES/configuration_files/ESGF_example/ESGF-Example_local.yaml
+++ b/RCMES/configuration_files/ESGF_example/ESGF-Example_local.yaml
@@ -36,20 +36,18 @@ regrid:
     regrid_on_reference: True
     regrid_dlat: 0.50
     regrid_dlon: 0.50
+    boundary_check: False
 
 datasets:
-    reference:
-        - loader_name: local
-          dataset_name: AVISO
-          file_path: ./data/ESGF_data/zos_AVISO_L4_199210-201012.nc
-          variable_name: zos
+  - loader_name: local
+    name: AVISO
+    file_path: ./data/ESGF_data/zos_AVISO_L4_199210-201012.nc
+    variable_name: zos
 
-    targets:
-        - loader_name: local
-          dataset_name: MPI-ESM-LR
-          file_path: ./data/ESGF_data/zos_Omon_MPI-ESM-LR_decadal1994_r1i1p1_199501-200412.nc
-          variable_name: zos
-          GCM_data: True
+  - loader_name: local
+    name: MPI-ESM-LR
+    file_path: ./data/ESGF_data/zos_Omon_MPI-ESM-LR_decadal1994_r1i1p1_199501-200412.nc
+    variable_name: zos
 
 number_of_metrics_and_plots: 1
 

--- a/RCMES/configuration_files/NARCCAP_examples/Fig10_and_Fig11.yaml
+++ b/RCMES/configuration_files/NARCCAP_examples/Fig10_and_Fig11.yaml
@@ -23,16 +23,14 @@ regrid:
     regrid_dlon: 0.50
 
 datasets:
-    reference:
-        - loader_name: rcmed
-          name: CRU
-          dataset_id: 10
-          parameter_id: 37
+  - loader_name: rcmed
+    name: CRU
+    dataset_id: 10
+    parameter_id: 37
 
-    targets:
-        - loader_name: local
-          file_path: ./data/NARCCAP_data/prec*ncep.monavg.nc
-          variable_name: prec
+  - loader_name: local
+    file_path: ./data/NARCCAP_data/prec*ncep.monavg.nc
+    variable_name: prec
 
 number_of_metrics_and_plots: 2
 

--- a/RCMES/configuration_files/NARCCAP_examples/Fig12_summer.yaml
+++ b/RCMES/configuration_files/NARCCAP_examples/Fig12_summer.yaml
@@ -23,16 +23,14 @@ regrid:
     regrid_dlon: 0.50
 
 datasets:
-    reference:
-        - loader_name: rcmed
-          name: CRU
-          dataset_id: 10
-          parameter_id: 37
+  - loader_name: rcmed
+    name: CRU
+    dataset_id: 10
+    parameter_id: 37
 
-    targets:
-        - loader_name: local
-          file_path: ./data/NARCCAP_data/prec*ncep.monavg.nc
-          variable_name: prec
+  - loader_name: local
+    file_path: ./data/NARCCAP_data/prec*ncep.monavg.nc
+    variable_name: prec
 
 number_of_metrics_and_plots: 1
 

--- a/RCMES/configuration_files/NARCCAP_examples/Fig12_winter.yaml
+++ b/RCMES/configuration_files/NARCCAP_examples/Fig12_winter.yaml
@@ -23,16 +23,14 @@ regrid:
     regrid_dlon: 0.50
 
 datasets:
-    reference:
-        - loader_name: rcmed
-          name: CRU
-          dataset_id: 10
-          parameter_id: 37
+  - loader_name: rcmed
+    name: CRU
+    dataset_id: 10
+    parameter_id: 37
 
-    targets:
-        - loader_name: local
-          file_path: ./data/NARCCAP_data/prec*ncep.monavg.nc
-          variable_name: prec
+  - loader_name: local
+    file_path: ./data/NARCCAP_data/prec*ncep.monavg.nc
+    variable_name: prec
 
 number_of_metrics_and_plots: 1
 

--- a/RCMES/configuration_files/NARCCAP_examples/Fig14_and_Fig15.yaml
+++ b/RCMES/configuration_files/NARCCAP_examples/Fig14_and_Fig15.yaml
@@ -23,16 +23,14 @@ regrid:
     regrid_dlon: 0.50
 
 datasets:
-    reference:
-        - loader_name: local
-          dataset_name: SRB
-          file_path: ./data/NARCCAP_data/srb_rel3.0_shortwave_from_1983_to_2007.nc
-          variable_name: sw_sfc_dn
+  - loader_name: local
+    name: SRB
+    file_path: ./data/NARCCAP_data/srb_rel3.0_shortwave_from_1983_to_2007.nc
+    variable_name: sw_sfc_dn
 
-    targets:
-        - loader_name: local
-          file_path: ./data/NARCCAP_data/rsds*ncep.monavg.nc
-          variable_name: rsds
+  - loader_name: local
+    file_path: ./data/NARCCAP_data/rsds*ncep.monavg.nc
+    variable_name: rsds
 
 number_of_metrics_and_plots: 2
 

--- a/RCMES/configuration_files/NARCCAP_examples/Fig16_summer.yaml
+++ b/RCMES/configuration_files/NARCCAP_examples/Fig16_summer.yaml
@@ -23,16 +23,14 @@ regrid:
     regrid_dlon: 0.50
 
 datasets:
-    reference:
-        - loader_name: local
-          dataset_name: SRB
-          file_path: ./data/NARCCAP_data/srb_rel3.0_shortwave_from_1983_to_2007.nc
-          variable_name: sw_sfc_dn
+  - loader_name: local
+    name: SRB
+    file_path: ./data/NARCCAP_data/srb_rel3.0_shortwave_from_1983_to_2007.nc
+    variable_name: sw_sfc_dn
 
-    targets:
-        - loader_name: local
-          file_path: ./data/NARCCAP_data/rsds*ncep.monavg.nc
-          variable_name: rsds    
+  - loader_name: local
+    file_path: ./data/NARCCAP_data/rsds*ncep.monavg.nc
+    variable_name: rsds
 
 number_of_metrics_and_plots: 1
 

--- a/RCMES/configuration_files/NARCCAP_examples/Fig16_winter.yaml
+++ b/RCMES/configuration_files/NARCCAP_examples/Fig16_winter.yaml
@@ -23,16 +23,14 @@ regrid:
     regrid_dlon: 0.50
 
 datasets:
-    reference:
-        - loader_name: local
-          dataset_name: SRB
-          file_path: ./data/NARCCAP_data/srb_rel3.0_shortwave_from_1983_to_2007.nc
-          variable_name: sw_sfc_dn
+  - loader_name: local
+    name: SRB
+    file_path: ./data/NARCCAP_data/srb_rel3.0_shortwave_from_1983_to_2007.nc
+    variable_name: sw_sfc_dn
 
-    targets:
-        - loader_name: local
-          file_path: ./data/NARCCAP_data/rsds*ncep.monavg.nc
-          variable_name: rsds
+  - loader_name: local
+    file_path: ./data/NARCCAP_data/rsds*ncep.monavg.nc
+    variable_name: rsds
 
 number_of_metrics_and_plots: 1
 

--- a/RCMES/configuration_files/NARCCAP_examples/Fig5_and_Fig6.yaml
+++ b/RCMES/configuration_files/NARCCAP_examples/Fig5_and_Fig6.yaml
@@ -23,16 +23,14 @@ regrid:
     regrid_dlon: 0.50
 
 datasets:
-    reference:
-        - loader_name: rcmed
-          name: CRU
-          dataset_id: 10
-          parameter_id: 38
+  - loader_name: rcmed
+    name: CRU
+    dataset_id: 10
+    parameter_id: 38
 
-    targets:
-        - loader_name: local
-          file_path: ./data/NARCCAP_data/temp.*ncep.monavg.nc
-          variable_name: temp    
+  - loader_name: local
+    file_path: ./data/NARCCAP_data/temp.*ncep.monavg.nc
+    variable_name: temp
 
 number_of_metrics_and_plots: 2
 

--- a/RCMES/configuration_files/NARCCAP_examples/Fig7_summer.yaml
+++ b/RCMES/configuration_files/NARCCAP_examples/Fig7_summer.yaml
@@ -23,16 +23,14 @@ regrid:
     regrid_dlon: 0.50
 
 datasets:
-    reference:
-        - loader_name: rcmed
-          name: CRU
-          dataset_id: 10
-          parameter_id: 38
+  - loader_name: rcmed
+    name: CRU
+    dataset_id: 10
+    parameter_id: 38
 
-    targets:
-        - loader_name: local
-          file_path: ./data/NARCCAP_data/temp*ncep.monavg.nc
-          variable_name: temp
+  - loader_name: local
+    file_path: ./data/NARCCAP_data/temp*ncep.monavg.nc
+    variable_name: temp
 
 number_of_metrics_and_plots: 1
 

--- a/RCMES/configuration_files/NARCCAP_examples/Fig7_winter.yaml
+++ b/RCMES/configuration_files/NARCCAP_examples/Fig7_winter.yaml
@@ -23,16 +23,14 @@ regrid:
     regrid_dlon: 0.50
 
 datasets:
-    reference:
-        - loader_name: rcmed
-          name: CRU
-          dataset_id: 10
-          parameter_id: 38
+  - loader_name: rcmed
+    name: CRU
+    dataset_id: 10
+    parameter_id: 38
 
-    targets:
-        - loader_name: local
-          file_path: ./data/NARCCAP_data/temp*ncep.monavg.nc
-          variable_name: temp
+  - loader_name: local
+    file_path: ./data/NARCCAP_data/temp*ncep.monavg.nc
+    variable_name: temp
 
 number_of_metrics_and_plots: 1
 

--- a/RCMES/configuration_files/NARCCAP_examples/Fig8_and_Fig9.yaml
+++ b/RCMES/configuration_files/NARCCAP_examples/Fig8_and_Fig9.yaml
@@ -23,16 +23,14 @@ regrid:
     regrid_dlon: 0.50
 
 datasets:
-    reference:
-        - loader_name: rcmed
-          name: CRU
-          dataset_id: 10
-          parameter_id: 37
+  - loader_name: rcmed
+    name: CRU
+    dataset_id: 10
+    parameter_id: 37
 
-    targets:
-        - loader_name: local
-          file_path: ./data/NARCCAP_data/prec.*ncep.monavg.nc
-          variable_name: prec
+  - loader_name: local
+    file_path: ./data/NARCCAP_data/prec.*ncep.monavg.nc
+    variable_name: prec
 
 number_of_metrics_and_plots: 2
 

--- a/RCMES/configuration_files/NASA_downscaling_project_Part1/dscale_prmo-eus_rcmed.yaml
+++ b/RCMES/configuration_files/NASA_downscaling_project_Part1/dscale_prmo-eus_rcmed.yaml
@@ -23,17 +23,15 @@ regrid:
     regrid_dlon: 0.125
 
 datasets:
-    reference:
-        - loader_name: rcmed
-          name: TRMM
-          dataset_id: 3
-          parameter_id: 36
-          variable_name: pr
+  - loader_name: rcmed
+    name: TRMM
+    dataset_id: 3
+    parameter_id: 36
+    variable_name: pr
 
-    targets:
-        - loader_name: local
-          file_path: ./data/dscale/prmo*.nc
-          variable_name: pr
+  - loader_name: local
+    file_path: ./data/dscale/prmo*.nc
+    variable_name: pr
 
 number_of_metrics_and_plots: 2
 

--- a/RCMES/configuration_files/NASA_downscaling_project_Part1/dscale_prmo-wus_local.yaml
+++ b/RCMES/configuration_files/NASA_downscaling_project_Part1/dscale_prmo-wus_local.yaml
@@ -23,16 +23,14 @@ regrid:
     regrid_dlon: 0.125
 
 datasets:
-    reference:
-        - loader_name: local
-          dataset_name: NLDAS
-          file_path: ./data/dscale/obs/prmo_lds-lds_1999-2010.nc
-          variable_name: pr
+  - loader_name: local
+    name: NLDAS
+    file_path: ./data/dscale/obs/prmo_lds-lds_1999-2010.nc
+    variable_name: pr
 
-    targets:
-        - loader_name: local
-          file_path: ./data/dscale/prmo*.nc
-          variable_name: pr
+  - loader_name: local
+    file_path: ./data/dscale/prmo*.nc
+    variable_name: pr
 
 number_of_metrics_and_plots: 2
 

--- a/RCMES/configuration_files/NASA_downscaling_project_Part1/dscale_prmo-wus_rcmed.yaml
+++ b/RCMES/configuration_files/NASA_downscaling_project_Part1/dscale_prmo-wus_rcmed.yaml
@@ -23,17 +23,15 @@ regrid:
     regrid_dlon: 0.125
 
 datasets:
-    reference:
-        - loader_name: rcmed
-          name: TRMM
-          dataset_id: 3
-          parameter_id: 36
-          variable_name: pr
+  - loader_name: rcmed
+    name: TRMM
+    dataset_id: 3
+    parameter_id: 36
+    variable_name: pr
 
-    targets:
-        - loader_name: local
-          file_path: ./data/dscale/prmo*.nc
-          variable_name: pr
+  - loader_name: local
+    file_path: ./data/dscale/prmo*.nc
+    variable_name: pr
 
 number_of_metrics_and_plots: 2
 

--- a/RCMES/configuration_files/NASA_downscaling_project_Part1/dscale_wus_prec_trmm_vs_nldas.yaml
+++ b/RCMES/configuration_files/NASA_downscaling_project_Part1/dscale_wus_prec_trmm_vs_nldas.yaml
@@ -23,17 +23,15 @@ regrid:
     regrid_dlon: 0.125
 
 datasets:
-    reference:
-        - loader_name: rcmed
-          name: TRMM
-          dataset_id: 3
-          parameter_id: 36
-          variable_name: pr
+  - loader_name: rcmed
+    name: TRMM
+    dataset_id: 3
+    parameter_id: 36
+    variable_name: pr
 
-    targets:
-        - loader_name: local
-          file_path: ./data/dscale/obs/prmo*.nc
-          variable_name: pr
+  - loader_name: local
+    file_path: ./data/dscale/obs/prmo*.nc
+    variable_name: pr
 
 number_of_metrics_and_plots: 2
 

--- a/RCMES/configuration_files/cordex_AF_prec_subregion_annual_cycle_time_series.yaml
+++ b/RCMES/configuration_files/cordex_AF_prec_subregion_annual_cycle_time_series.yaml
@@ -23,16 +23,14 @@ regrid:
     regrid_dlon: 0.44
 
 datasets:
-    reference:
-        - loader_name: rcmed
-          name: CRU
-          dataset_id: 10
-          parameter_id: 37
+  - loader_name: rcmed
+    name: CRU
+    dataset_id: 10
+    parameter_id: 37
 
-    targets:
-        - loader_name: local
-          file_path: ./data/config_training/AFRICA*pr.nc
-          variable_name: pr
+  - loader_name: local
+    file_path: ./data/config_training/AFRICA*pr.nc
+    variable_name: pr
 
 number_of_metrics_and_plots: 1
 

--- a/RCMES/run_RCMES.py
+++ b/RCMES/run_RCMES.py
@@ -53,9 +53,9 @@ def load_datasets_from_config(extra_opts, *loader_opts):
             opt['start_time'] = extra_opts['start_time']
             opt['end_time'] = extra_opts['end_time']
 
-        loader = DatasetLoader(*loader_opts)
-        loader.load_datasets()
-        return loader.datasets
+    loader = DatasetLoader(*loader_opts)
+    loader.load_datasets()
+    return loader.datasets
 
 if hasattr(ssl, '_create_unverified_context'):
     ssl._create_default_https_context = ssl._create_unverified_context

--- a/RCMES/run_RCMES.py
+++ b/RCMES/run_RCMES.py
@@ -15,6 +15,7 @@
 # specific language governing permissions and limitations
 # under the License.
 
+from __future__ import print_function
 import os
 import sys
 import ssl
@@ -61,7 +62,7 @@ if hasattr(ssl, '_create_unverified_context'):
 
 config_file = str(sys.argv[1])
 
-print 'Reading the configuration file ', config_file
+print('Reading the configuration file {}'.format(config_file))
 config = yaml.load(open(config_file))
 time_info = config['time']
 temporal_resolution = time_info['temporal_resolution']
@@ -86,55 +87,36 @@ extra_opts = {'min_lat': min_lat, 'max_lat': max_lat, 'min_lon': min_lon,
               'end_time': end_time, 'username': None, 'password': None}
 
 # Get the dataset loader options
-obs_data_info = config['datasets']['reference']
-model_data_info = config['datasets']['targets']
+data_info = config['datasets']
 
 # Extract info we don't want to put into the loader config
 # Multiplying Factor to scale obs by
-multiplying_factor = np.ones(len(obs_data_info))
-for i, info in enumerate(obs_data_info):
-    if 'multiplying_factor' in info:
-        multiplying_factor[i] = info.pop('multiplying_factor')
-
-# If models are GCMs we can skip boundary check. Probably need to find a more
-# elegant way to express this in the config file API.
-boundary_check = True
-for i, info in enumerate(model_data_info):
-    if 'boundary_check' in info:
-        boundary_check = info.pop('boundary_check')
-
-""" Step 1: Load the observation data """
-print 'Loading observation datasets:\n',obs_data_info
-obs_datasets = load_datasets_from_config(extra_opts, *obs_data_info)
-obs_names = [dataset.name for dataset in obs_datasets]
-for i, dataset in enumerate(obs_datasets):
+multiplying_factor = np.ones(len(data_info))
+for i, info in enumerate(reference_data_info):
+    multiplying_factor[i] = info.pop('multiplying_factor', 1)
+    
+""" Step 1: Load the datasets """
+print('Loading datasets:\n{}'.format(data_info))
+datasets = load_datasets_from_config(extra_opts, *data_info)
+names = [dataset.name for dataset in datasets]
+for i, dataset in enumerate(datasets):
     if temporal_resolution == 'daily' or temporal_resolution == 'monthly':
-        obs_datasets[i] = dsp.normalize_dataset_datetimes(dataset,
-                                                          temporal_resolution)
+        datasets[i] = dsp.normalize_dataset_datetimes(dataset,
+                                                      temporal_resolution)
+        datasets[i].values *= multiplying_factor[i]
 
-    if multiplying_factor[i] != 1:
-        obs_datasets[i].values *= multiplying_factor[i]
-
-""" Step 2: Load model NetCDF Files into OCW Dataset Objects """
-model_datasets = load_datasets_from_config(extra_opts, *model_data_info)
-model_names = [dataset.name for dataset in model_datasets]
-if temporal_resolution == 'daily' or temporal_resolution == 'monthly':
-    for i, dataset in enumerate(model_datasets):
-        model_datasets[i] = dsp.normalize_dataset_datetimes(dataset,
-                                                            temporal_resolution)
-
-""" Step 3: Subset the data for temporal and spatial domain """
+""" Step 2: Subset the data for temporal and spatial domain """
 # Create a Bounds object to use for subsetting
 if time_info['maximum_overlap_period']:
-    start_time, end_time = utils.get_temporal_overlap(obs_datasets+model_datasets)
-    print 'Maximum overlap period'
-    print 'start_time:', start_time
-    print 'end_time:', end_time
+    start_time, end_time = utils.get_temporal_overlap(datasets)
+    print('Maximum overlap period')
+    print('start_time: {}'.format(start_time))
+    print('end_time: {}'.format(end_time))
 
 if temporal_resolution == 'monthly' and end_time.day !=1:
     end_time = end_time.replace(day=1)
 
-for i, dataset in enumerate(obs_datasets):
+for i, dataset in enumerate(datasets):
     min_lat = np.max([min_lat, dataset.lats.min()])
     max_lat = np.min([max_lat, dataset.lats.max()])
     min_lon = np.max([min_lon, dataset.lons.min()])
@@ -152,15 +134,10 @@ else:
                     start=start_time,
                     end=end_time)
 
-for i, dataset in enumerate(obs_datasets):
-    obs_datasets[i] = dsp.subset(dataset, bounds)
+for i, dataset in enumerate(datasets):
+    datasets[i] = dsp.subset(dataset, bounds)
     if dataset.temporal_resolution() != temporal_resolution:
-        obs_datasets[i] = dsp.temporal_rebin(dataset, temporal_resolution)
-
-for i, dataset in enumerate(model_datasets):
-    model_datasets[i] = dsp.subset(dataset, bounds)
-    if dataset.temporal_resolution() != temporal_resolution:
-        model_datasets[i] = dsp.temporal_rebin(dataset, temporal_resolution)
+        datasets[i] = dsp.temporal_rebin(dataset, temporal_resolution)
 
 # Temporally subset both observation and model datasets
 # for the user specified season
@@ -168,19 +145,21 @@ month_start = time_info['month_start']
 month_end = time_info['month_end']
 average_each_year = time_info['average_each_year']
 
-# TODO: Fully support multiple observation / reference datasets.
-# For now we will only use the first reference dataset listed in the config file
-obs_dataset = obs_datasets[0]
-obs_name = obs_names[0]
-obs_dataset = dsp.temporal_subset(obs_dataset,month_start, month_end,average_each_year)
-for i, dataset in enumerate(model_datasets):
-    model_datasets[i] = dsp.temporal_subset(dataset, month_start, month_end,
-                                            average_each_year)
+# For now we will treat the first listed dataset as the reference dataset for
+# evaluation purposes.
+for i, dataset in enumerate(datasets):
+    datasets[i] = dsp.temporal_subset(dataset, month_start, month_end,
+                                      average_each_year)
+
+reference_dataset = datasets[0]
+target_datasets = datasets[1:]
+reference_name = names[0]
+target_names = names[1:]
 
 # generate grid points for regridding
 if config['regrid']['regrid_on_reference']:
-    new_lat = obs_dataset.lats
-    new_lon = obs_dataset.lons
+    new_lat = reference_dataset.lats
+    new_lon = reference_dataset.lons
 else:
     delta_lat = config['regrid']['regrid_dlat']
     delta_lon = config['regrid']['regrid_dlon']
@@ -189,40 +168,45 @@ else:
     new_lat = np.linspace(min_lat, max_lat, nlat)
     new_lon = np.linspace(min_lon, max_lon, nlon)
 
-# number of models
-nmodel = len(model_datasets)
-print 'Dataset loading completed'
-print 'Observation data:', obs_name
-print 'Number of model datasets:',nmodel
-for model_name in model_names:
-    print model_name
+# Get flag for boundary checking for regridding. By default, this is set to True
+# since the main intent of this program is to evaluate RCMs. However, it can be
+# used for GCMs in which case it should be set to False to save time.
+boundary_check = config['regrid'].get('boundary_check', True)
 
-""" Step 4: Spatial regriding of the reference datasets """
-print 'Regridding datasets: ', config['regrid']
+# number of target datasets (usually models, but can also be obs / reanalysis)
+ntarget = len(target_datasets)
+print('Dataset loading completed')
+print('Reference data: {}'.format(reference_name))
+print('Number of target datasets: {}'.format(ntarget))
+for target_name in target_names:
+    print(target_name)
+
+""" Step 3: Spatial regriding of the datasets """
+print('Regridding datasets: {}'.format(config['regrid']))
 if not config['regrid']['regrid_on_reference']:
-    obs_dataset = dsp.spatial_regrid(obs_dataset, new_lat, new_lon)
-    print 'Reference dataset has been regridded'
-for i, dataset in enumerate(model_datasets):
-    model_datasets[i] = dsp.spatial_regrid(dataset, new_lat, new_lon,
+    reference_dataset = dsp.spatial_regrid(reference_dataset, new_lat, new_lon)
+    print('Reference dataset has been regridded')
+for i, dataset in enumerate(target_datasets):
+    target_datasets[i] = dsp.spatial_regrid(dataset, new_lat, new_lon,
                                            boundary_check=boundary_check)
-    print model_names[i]+' has been regridded'
-print 'Propagating missing data information'
-obs_dataset = dsp.mask_missing_data([obs_dataset]+model_datasets)[0]
-model_datasets = dsp.mask_missing_data([obs_dataset]+model_datasets)[1:]
+    print('{} has been regridded'.format(target_names[i]))
+print('Propagating missing data information')
+datasets = dsp.mask_missing_data([reference_dataset]+target_datasets)
+reference_dataset = datasets[0]
+target_datasets = datasets[1:]
 
-""" Step 5: Checking and converting variable units """
-print 'Checking and converting variable units'
-obs_dataset = dsp.variable_unit_conversion(obs_dataset)
-for idata,dataset in enumerate(model_datasets):
-    model_datasets[idata] = dsp.variable_unit_conversion(dataset)
+""" Step 4: Checking and converting variable units """
+print('Checking and converting variable units')
+reference_dataset = dsp.variable_unit_conversion(reference_dataset)
+for i, dataset in enumerate(target_datasets):
+    target_datasets[i] = dsp.variable_unit_conversion(dataset)
 
+print('Generating multi-model ensemble')
+if len(target_datasets) >= 2.:
+    target_datasets.append(dsp.ensemble(target_datasets))
+    target_names.append('ENS')
 
-print 'Generating multi-model ensemble'
-if len(model_datasets) >= 2.:
-    model_datasets.append(dsp.ensemble(model_datasets))
-    model_names.append('ENS')
-
-""" Step 6: Generate subregion average and standard deviation """
+""" Step 5: Generate subregion average and standard deviation """
 if config['use_subregions']:
     # sort the subregion by region names and make a list
     subregions= sorted(config['subregions'].items(),key=operator.itemgetter(0))
@@ -230,94 +214,94 @@ if config['use_subregions']:
     # number of subregions
     nsubregion = len(subregions)
 
-    print ('Calculating spatial averages and standard deviations of ',
-        str(nsubregion),' subregions')
+    print('Calculating spatial averages and standard deviations of {} subregions'
+          .format(nsubregions))
 
-    obs_subregion_mean, obs_subregion_std, subregion_array = (
-        utils.calc_subregion_area_mean_and_std([obs_dataset], subregions))
-    model_subregion_mean, model_subregion_std, subregion_array = (
-        utils.calc_subregion_area_mean_and_std(model_datasets, subregions))
+    reference_subregion_mean, reference_subregion_std, subregion_array = (
+        utils.calc_subregion_area_mean_and_std([reference_dataset], subregions))
+    target_subregion_mean, target_subregion_std, subregion_array = (
+        utils.calc_subregion_area_mean_and_std(target_datasets, subregions))
 
-""" Step 7: Write a netCDF file """
+""" Step 6: Write a netCDF file """
 workdir = config['workdir']
 if workdir[-1] != '/':
     workdir = workdir+'/'
-print 'Writing a netcdf file: ',workdir+config['output_netcdf_filename']
+print('Writing a netcdf file: ',workdir+config['output_netcdf_filename'])
 if not os.path.exists(workdir):
     os.system("mkdir -p "+workdir)
 
 if config['use_subregions']:
     dsp.write_netcdf_multiple_datasets_with_subregions(
-        obs_dataset, obs_name, model_datasets, model_names,
+        reference_dataset, reference_name, target_datasets, target_names,
         path=workdir+config['output_netcdf_filename'],
         subregions=subregions, subregion_array=subregion_array,
-        ref_subregion_mean=obs_subregion_mean,
-        ref_subregion_std=obs_subregion_std,
-        model_subregion_mean=model_subregion_mean,
-        model_subregion_std=model_subregion_std)
+        ref_subregion_mean=reference_subregion_mean,
+        ref_subregion_std=reference_subregion_std,
+        target_subregion_mean=target_subregion_mean,
+        target_subregion_std=target_subregion_std)
 else:
     dsp.write_netcdf_multiple_datasets_with_subregions(
-                                obs_dataset, obs_name, model_datasets,
-                                model_names,
+                                reference_dataset, reference_name, target_datasets,
+                                target_names,
                                 path=workdir+config['output_netcdf_filename'])
 
-""" Step 8: Calculate metrics and draw plots """
+""" Step 7: Calculate metrics and draw plots """
 nmetrics = config['number_of_metrics_and_plots']
 if config['use_subregions']:
-    Map_plot_subregion(subregions, obs_dataset, workdir)
+    Map_plot_subregion(subregions, reference_dataset, workdir)
 
 if nmetrics > 0:
-    print 'Calculating metrics and generating plots'
+    print('Calculating metrics and generating plots')
     for imetric in np.arange(nmetrics)+1:
         metrics_name = config['metrics'+'%1d' %imetric]
         plot_info = config['plots'+'%1d' %imetric]
         file_name = workdir+plot_info['file_name']
 
-        print 'metrics '+str(imetric)+'/'+str(nmetrics)+': ', metrics_name
+        print('metrics {0}/{1}: {2}'.format(imetric, nmetrics, metrics_name))
         if metrics_name == 'Map_plot_bias_of_multiyear_climatology':
             row, column = plot_info['subplots_array']
             if 'map_projection' in plot_info.keys():
                 Map_plot_bias_of_multiyear_climatology(
-                    obs_dataset, obs_name, model_datasets, model_names,
+                    reference_dataset, reference_name, target_datasets, target_names,
                     file_name, row, column,
                     map_projection=plot_info['map_projection'])
             else:
                 Map_plot_bias_of_multiyear_climatology(
-                    obs_dataset, obs_name, model_datasets, model_names,
+                    reference_dataset, reference_name, target_datasets, target_names,
                     file_name, row, column)
         elif metrics_name == 'Taylor_diagram_spatial_pattern_of_multiyear_climatology':
             Taylor_diagram_spatial_pattern_of_multiyear_climatology(
-                obs_dataset, obs_name, model_datasets, model_names,
+                reference_dataset, reference_name, target_datasets, target_names,
                 file_name)
         elif config['use_subregions']:
             if (metrics_name == 'Timeseries_plot_subregion_interannual_variability'
                 and average_each_year):
                 row, column = plot_info['subplots_array']
                 Time_series_subregion(
-                    obs_subregion_mean, obs_name, model_subregion_mean,
-                    model_names, False, file_name, row, column,
+                    reference_subregion_mean, reference_name, target_subregion_mean,
+                    target_names, False, file_name, row, column,
                     x_tick=['Y'+str(i+1)
-                            for i in np.arange(model_subregion_mean.shape[1])])
+                            for i in np.arange(target_subregion_mean.shape[1])])
 
             if (metrics_name == 'Timeseries_plot_subregion_annual_cycle'
                 and not average_each_year and month_start==1 and month_end==12):
                 row, column = plot_info['subplots_array']
                 Time_series_subregion(
-                    obs_subregion_mean, obs_name,
-                    model_subregion_mean, model_names, True,
+                    reference_subregion_mean, reference_name,
+                    target_subregion_mean, target_names, True,
                     file_name, row, column,
                     x_tick=['J','F','M','A','M','J','J','A','S','O','N','D'])
 
             if (metrics_name == 'Portrait_diagram_subregion_interannual_variability'
                 and average_each_year):
-                Portrait_diagram_subregion(obs_subregion_mean, obs_name,
-                                           model_subregion_mean, model_names,
+                Portrait_diagram_subregion(reference_subregion_mean, reference_name,
+                                           target_subregion_mean, target_names,
                                            False, file_name)
 
             if (metrics_name == 'Portrait_diagram_subregion_annual_cycle'
                 and not average_each_year and month_start==1 and month_end==12):
-                Portrait_diagram_subregion(obs_subregion_mean, obs_name,
-                                           model_subregion_mean, model_names,
+                Portrait_diagram_subregion(reference_subregion_mean, reference_name,
+                                           target_subregion_mean, target_names,
                                            True, file_name)
         else:
-            print 'please check the currently supported metrics'
+            print('please check the currently supported metrics')


### PR DESCRIPTION
This PR will generalize RCMES to handle all datasets in the same way. Now rather than making any distinction from observation and model in the code, all datasets are loaded at once with the first dataset listed being designated as the reference for binary metrics. Theoretically, this capability was already possible but these changes should make it feel a bit more streamlined.

## Todos

- [x] Update configuration files in examples
- [ ] Test an example configuration file with only observation / reanalysis datasets. 