### PR TITLE
CLIMATE-929 - Incorrect indices used for temporal subset after trimming

### DIFF
--- a/ocw/dataset_processor.py
+++ b/ocw/dataset_processor.py
@@ -83,9 +83,9 @@ def temporal_subset(target_dataset, month_start, month_end,
             logger.warning("Number of times in dataset ({}) does not "
                            "divide evenly into {} year(s). Trimming data..."
                            .format(ntime, nyear))
-            s_mon = new_times[0].month
-            e_mon = new_times[-1].month
-            new_times = new_times[13-s_mon:-e_mon]
+            slc = utils.trim_dataset(new_dataset)
+            new_dataset.values = new_dataset.values[slc]
+            new_times = new_times[slc]
             nyear = new_times.size // nmonth
 
         averaged_time = []

--- a/ocw/utils.py
+++ b/ocw/utils.py
@@ -383,14 +383,34 @@ def get_temporal_overlap(dataset_array):
     ''' Find the maximum temporal overlap across the observation and model datasets
 
     :param dataset_array: an array of OCW datasets
+    :param idx: start and end indices to denote subset of months used.
+    :type idx: class:`tuple`
     '''
-    start_time = []
-    end_time = []
+    start_times = []
+    end_times = []
     for dataset in dataset_array:
-        start_time.append(dataset.temporal_boundaries()[0])
-        end_time.append(dataset.temporal_boundaries()[1])
+        slc = trim_dataset(dataset)
+        times = dataset.times[slc]
+        start_time, end_time = times[0], times[-1]
+        start_times.append(start_time)
+        end_times.append(end_time)
 
-    return np.max(start_time), np.min(end_time)
+    return np.max(start_times), np.min(end_times)
+
+
+def trim_dataset(dataset):
+    ''' Trim datasets such that first and last year of data have all 12 months
+
+    :param dataset: Dataset object
+    :type dataset: :class:`dataset.Dataset
+
+    :returns: Slice index for trimmed dataset
+    '''
+    start_time, end_time = dataset.temporal_boundaries()
+    start_month = 13 if start_time.month == 1 else start_time.month
+    end_month = 0 if end_time.month == 12 else end_time.month
+    slc = slice(13 - start_month, len(dataset.times) - end_month)
+    return slc
 
 
 def calc_subregion_area_mean_and_std(dataset_array, subregions):
@@ -505,33 +525,33 @@ def CORDEX_boundary(domain_name):
     :param domain_name: CORDEX domain name (http://www.cordex.org/)
     :type domain_name: :mod:'string'
     '''
-    if domain_name == 'southamerica' or domain_name == 'SAM':
+    if domain_name == 'southamerica' or domain_name == 'sam':
         return -57.61, 18.50, 254.28 - 360., 343.02 - 360.
-    elif domain_name == 'centralamerica' or domain_name == 'CAM':
+    elif domain_name == 'centralamerica' or domain_name == 'cam':
         return -19.46, 34.83, 235.74 - 360., 337.78 - 360.
-    elif domain_name == 'northamerica' or domain_name == 'NAM':
+    elif domain_name == 'northamerica' or domain_name == 'nam':
         return 12.55, 75.88, 189.26 - 360., 336.74 - 360.
-    elif domain_name == 'europe' or domain_name == 'EUR':
+    elif domain_name == 'europe' or domain_name == 'eur':
         return 22.20, 71.84, 338.23 - 360., 64.4
-    elif domain_name == 'africa' or domain_name == 'AFR':
+    elif domain_name == 'africa' or domain_name == 'afr':
         return -45.76, 42.24, 335.36 - 360., 60.28
-    elif domain_name == 'southasia' or domain_name == 'WAS':
+    elif domain_name == 'southasia' or domain_name == 'was':
         return -15.23, 45.07, 19.88, 115.55
-    elif domain_name == 'eastasia' or domain_name == 'EAS':
+    elif domain_name == 'eastasia' or domain_name == 'eas':
         return -0.10, 61.90, 51.59, 179.99
-    elif domain_name == 'centralasia' or domain_name == 'CAS':
+    elif domain_name == 'centralasia' or domain_name == 'cas':
         return 18.34, 69.37, 11.05, 139.13
-    elif domain_name == 'australasia' or domain_name == 'AUS':
+    elif domain_name == 'australasia' or domain_name == 'aus':
         return -52.36, 12.21, 89.25, 179.99
-    elif domain_name == 'antartica' or domain_name == 'ANT':
+    elif domain_name == 'antartica' or domain_name == 'ant':
         return -89.48, -56.00, -179.00, 179.00
-    elif domain_name == 'artic' or domain_name == 'ARC':
+    elif domain_name == 'artic' or domain_name == 'arc':
         return 46.06, 89.50, -179.00, 179.00
-    elif domain_name == 'mediterranean' or domain_name == 'MED':
+    elif domain_name == 'mediterranean' or domain_name == 'med':
         return 25.63, 56.66, 339.79 - 360.00, 50.85
-    elif domain_name == 'middleeastnorthafrica' or domain_name == 'MNA':
+    elif domain_name == 'middleeastnorthafrica' or domain_name == 'mna':
         return -7.00, 45.00, 333.00 - 360.00, 76.00
-    elif domain_name == 'southeastasia' or domain_name == 'SEA':
+    elif domain_name == 'southeastasia' or domain_name == 'sea':
         return -15.14, 27.26, 89.26, 146.96
     else:
         err = "Invalid CORDEX domain name"


### PR DESCRIPTION
- Fixes a bug introduced by CLIMATE-928
- Minor fixes to CORDEX boundary generator to make it accept acronym inputs