### PR TITLE
CLIMATE-941 Value Error When Bounds Object Is Created Without Named I…

### DIFF
--- a/ocw-ui/backend/processing.py
+++ b/ocw-ui/backend/processing.py
@@ -203,12 +203,12 @@ def run_evaluation():
             day_offset = end.day - 1
             end -= timedelta(days=day_offset)
 
-    subset = Bounds(eval_bounds['lat_min'],
-                    eval_bounds['lat_max'],
-                    eval_bounds['lon_min'],
-                    eval_bounds['lon_max'],
-                    start,
-                    end)
+    subset = Bounds(lat_min=eval_bounds['lat_min'],
+                    lat_max=eval_bounds['lat_max'],
+                    lon_min=eval_bounds['lon_min'],
+                    lon_max=eval_bounds['lon_max'],
+                    start=start,
+                    end=end)
 
     ref_dataset = dsp.safe_subset(ref_dataset, subset)
     target_datasets = [dsp.safe_subset(ds, subset)


### PR DESCRIPTION
CLIMATE-941 Value Error When Bounds Object Is Created Without Named Inputs

- Corrected Bounds object being created without named inputs causing Value Error by adding names to input values.