### PR TITLE
CLIMATE-388 Make UI backend parameters endpoint more RESTful

### DIFF
--- a/ocw-ui/frontend/app/scripts/controllers/rcmedselection.js
+++ b/ocw-ui/frontend/app/scripts/controllers/rcmedselection.js
@@ -81,9 +81,9 @@ angular.module('ocwUiApp')
       };
 
       $scope.dataSelectUpdated = function() {
-        var urlString = $rootScope.baseURL + '/rcmed/parameters/?dataset=' +
+        var urlString = $rootScope.baseURL + '/rcmed/parameters/dataset/' +
                         $scope.datasetSelection["shortname"] +
-                        "&callback=JSON_CALLBACK";
+                        "?callback=JSON_CALLBACK";
         $http.jsonp(urlString)
           .success(function(data) {
             $scope.retrievedObsParams = data;

--- a/ocw-ui/frontend/test/spec/controllers/rcmedselection.js
+++ b/ocw-ui/frontend/test/spec/controllers/rcmedselection.js
@@ -84,9 +84,9 @@ describe('Controller: RcmedSelectionCtrl', function () {
       scope.datasetSelection = {shortname: 'TRMM'}
 
       // Test return with only single parameter
-      $httpBackend.expectJSONP($rootScope.baseURL + '/rcmed/parameters/?dataset=' +
+      $httpBackend.expectJSONP($rootScope.baseURL + '/rcmed/parameters/dataset/' +
                   scope.datasetSelection['shortname'] +
-                  '&callback=JSON_CALLBACK').
+                  '?callback=JSON_CALLBACK').
              respond(200, ['pcp']);
       scope.dataSelectUpdated();
       $httpBackend.flush();
@@ -94,9 +94,9 @@ describe('Controller: RcmedSelectionCtrl', function () {
       expect(scope.parameterSelection).toEqual('pcp');
 
       // Test return with multiple parameters
-      $httpBackend.expectJSONP($rootScope.baseURL + '/rcmed/parameters/?dataset=' +
+      $httpBackend.expectJSONP($rootScope.baseURL + '/rcmed/parameters/dataset/' +
                   scope.datasetSelection['shortname'] +
-                  '&callback=JSON_CALLBACK').
+                  '?callback=JSON_CALLBACK').
              respond(200, ['pcp', 'pcp2']);
       scope.dataSelectUpdated();
       $httpBackend.flush();


### PR DESCRIPTION
CLIMATE-388 Make UI backend parameters endpoint more RESTful

- Change query parameter to path parameter.
- Change route annotation to get annotation.
- Pylint.