### PR TITLE
CLIMATE-943 TypeError: Cannot set property uiDateValidator of undefined

### DIFF
--- a/ocw-ui/frontend/app/scripts/controllers/parameterselect.js
+++ b/ocw-ui/frontend/app/scripts/controllers/parameterselect.js
@@ -27,8 +27,8 @@
  * Controller of the ocwUiApp
  */
 angular.module('ocwUiApp')
-.controller('ParameterSelectCtrl', ['$rootScope', '$scope', '$http', '$timeout', 
-						   'selectedDatasetInformation', 'regionSelectParams', 'evaluationSettings', 
+.controller('ParameterSelectCtrl', ['$rootScope', '$scope', '$http', '$timeout',
+						   'selectedDatasetInformation', 'regionSelectParams', 'evaluationSettings',
   function($rootScope, $scope, $http, $timeout, selectedDatasetInformation, regionSelectParams, evaluationSettings) {
     $scope.datasets = selectedDatasetInformation.getDatasets();
 
@@ -77,6 +77,20 @@ angular.module('ocwUiApp')
 
       return res;
     }
+
+   let formatDate = function(oldDate) {
+
+        let newDate = new Date(oldDate);
+
+        let year = newDate.getFullYear();
+
+        let month = ((newDate.getMonth() + 1) < 10) ? '0' + (newDate.getMonth() + 1).toString: (newDate.getMonth() + 1);
+
+        let day = (newDate.getDate() < 10) ? '0' + newDate.getDate().toString: newDate.getDate();
+
+        return newDate.getFullYear() + '-' + (newDate.getMonth() + 1) + '-' + newDate.getDate();
+    }
+
 
     $scope.runEvaluation = function() {
       $scope.runningEval = true;
@@ -145,6 +159,8 @@ angular.module('ocwUiApp')
         data['temporal_resolution'] = 30;
       }
 
+      data['temporal_resolution_type'] = temporal_res
+
       // Load the Metrics for the evaluation
       data['metrics'] = []
       var metrics = settings.metrics
@@ -157,8 +173,8 @@ angular.module('ocwUiApp')
       }
 
       // Set the bound values for the evaluation
-      data['start_time'] =  $scope.displayParams.start + " 00:00:00",
-      data['end_time'] = $scope.displayParams.end + " 00:00:00",
+      data['start_time'] =  formatDate($scope.displayParams.start) + " 00:00:00",
+      data['end_time'] = formatDate($scope.displayParams.end) + " 00:00:00",
       data['lat_min'] = $scope.displayParams.latMin,
       data['lat_max'] = $scope.displayParams.latMax,
       data['lon_min'] = $scope.displayParams.lonMin,
@@ -177,7 +193,7 @@ angular.module('ocwUiApp')
             window.location = "#/results";
           }
         }, 100);
-        
+
       }).error(function() {
         $scope.runningEval = false;
       });
@@ -192,13 +208,13 @@ angular.module('ocwUiApp')
       if (parseFloat($scope.displayParams.latMax) > parseFloat($scope.latMax))
         $scope.displayParams.latMax = $scope.latMax;
 
-      if (parseFloat($scope.displayParams.lonMin) < parseFloat($scope.lonMin)) 
+      if (parseFloat($scope.displayParams.lonMin) < parseFloat($scope.lonMin))
         $scope.displayParams.lonMin = $scope.lonMin;
 
-      if (parseFloat($scope.displayParams.lonMax) > parseFloat($scope.lonMax)) 
+      if (parseFloat($scope.displayParams.lonMax) > parseFloat($scope.lonMax))
         $scope.displayParams.lonMax = $scope.lonMax;
 
-      if ($scope.displayParams.start < $scope.start) 
+      if ($scope.displayParams.start < $scope.start)
         $scope.displayParams.start = $scope.start;
 
       if ($scope.displayParams.end > $scope.end)
@@ -213,8 +229,8 @@ angular.module('ocwUiApp')
       $rootScope.$broadcast('redrawOverlays', []);
     }
 
-    $scope.unwatchDatasets = $scope.$watch('datasets', 
-      function() { 
+    $scope.unwatchDatasets = $scope.$watch('datasets',
+      function() {
         var numDatasets = $scope.datasets.length;
         $scope.displayParams.areValid = false;
         $scope.areInUserRegridState = false;
@@ -230,13 +246,13 @@ angular.module('ocwUiApp')
           // Get the valid lat/lon range in the selected datasets.
           for (var i = 0; i < numDatasets; i++) {
             var curDataset = $scope.datasets[i];
-    
+
             latMin = (curDataset['latlonVals']['latMin'] > latMin) ? curDataset['latlonVals']['latMin'] : latMin;
             latMax = (curDataset['latlonVals']['latMax'] < latMax) ? curDataset['latlonVals']['latMax'] : latMax;
             lonMin = (curDataset['latlonVals']['lonMin'] > lonMin) ? curDataset['latlonVals']['lonMin'] : lonMin;
             lonMax = (curDataset['latlonVals']['lonMax'] < lonMax) ? curDataset['latlonVals']['lonMax'] : lonMax;
-            start = (curDataset['timeVals']['start'] > start) ? curDataset['timeVals']['start'] : start;
-            end = (curDataset['timeVals']['end'] < end) ? curDataset['timeVals']['end'] : end;
+            start = (curDataset['timeVals']['start'] > start) ? new Date(curDataset['timeVals']['start']) : start;
+            end = (curDataset['timeVals']['end'] < end) ? new Date(curDataset['timeVals']['end']) : end;
 
             datasetRegrid = datasetRegrid || curDataset.regrid;
 
@@ -250,16 +266,16 @@ angular.module('ocwUiApp')
         $scope.displayParams.latMax = $scope.truncateFloat(latMax);
         $scope.displayParams.lonMin = $scope.truncateFloat(lonMin);
         $scope.displayParams.lonMax = $scope.truncateFloat(lonMax);
-        $scope.displayParams.start = (typeof start == 'undefined') ? "" : start.split(" ")[0];
-        $scope.displayParams.end = (typeof end == 'undefined') ? "" : end.split(" ")[0];
+        $scope.displayParams.start = (typeof start == 'undefined') ? "" : new Date(start);
+        $scope.displayParams.end = (typeof end == 'undefined') ? "" : new Date(end);
 
         // Update the local store values!
         $scope.latMin = latMin;
         $scope.latMax = latMax;
         $scope.lonMin = lonMin;
         $scope.lonMax = lonMax;
-        $scope.start = (typeof start == 'undefined') ? "" : start.split(" ")[0];
-        $scope.end = (typeof end == 'undefined') ? "" : end.split(" ")[0];
+        $scope.start = (typeof start == 'undefined') ? "" : start;
+        $scope.end = (typeof end == 'undefined') ? "" : end;
 
         $scope.displayParams.areValid = true;
         $rootScope.$broadcast('redrawOverlays', []);

--- a/ocw-ui/frontend/app/scripts/controllers/rcmedselection.js
+++ b/ocw-ui/frontend/app/scripts/controllers/rcmedselection.js
@@ -81,16 +81,20 @@ angular.module('ocwUiApp')
       };
 
       $scope.dataSelectUpdated = function() {
-        var urlString = $rootScope.baseURL + '/rcmed/parameters/?dataset=' +
-                        $scope.datasetSelection["shortname"] +
-                        "&callback=JSON_CALLBACK";
-        $http.jsonp(urlString)
-          .success(function(data) {
-            $scope.retrievedObsParams = data;
-            if ($scope.retrievedObsParams.length > 1)
-              $scope.retrievedObsParams.splice(0, 0, {shortname: 'Please select a parameter'});
-            $scope.parameterSelection = $scope.retrievedObsParams[0];
-          });
+        if ($scope.datasetSelection) {
+          var urlString = $rootScope.baseURL + '/rcmed/parameters/dataset/' +
+            $scope.datasetSelection["shortname"] +
+            "?callback=JSON_CALLBACK";
+
+         $http.jsonp(urlString)
+           .success(function(data) {
+             $scope.retrievedObsParams = data;
+             if ($scope.retrievedObsParams.length > 1)
+               $scope.retrievedObsParams.splice(0, 0, {longname: 'Please select a parameter'});
+             $scope.parameterSelection = $scope.retrievedObsParams[0];
+            }
+           );
+        }
       };
 
       $scope.addObservation = function() {

--- a/ocw-ui/frontend/app/scripts/controllers/timeline.js
+++ b/ocw-ui/frontend/app/scripts/controllers/timeline.js
@@ -41,7 +41,7 @@ function($rootScope, $scope, selectedDatasetInformation, regionSelectParams) {
 		// Don't process if no datasets have been added
 		if ($scope.datasets.length == 0 || !("timeline" in $rootScope))
 			return;
- 		
+
 		// Create DataTable to add data to timeline
 		var data = new google.visualization.DataTable();
 		data.addColumn('datetime', 'start');
@@ -66,7 +66,7 @@ function($rootScope, $scope, selectedDatasetInformation, regionSelectParams) {
 												 new Date(end.substr(0, 4), end.substr(5, 2) - 1, end.substr(8, 2)));
 
 		// Add user selected bounds to timeline
-		if ($scope.regionParams.areValid) {
+		if ($scope.regionParams.start && $scope.regionParams.end) {
 
 			var userStart 	= $scope.regionParams.start;
 			var userEnd 	= $scope.regionParams.end;
@@ -74,22 +74,22 @@ function($rootScope, $scope, selectedDatasetInformation, regionSelectParams) {
 			// Add color to user selected bounds
 			var style = 'background-color: #000000; border: 2px solid;';
 			var ocwBar = '<div class="ocw-bar timeline-event-range" style="' + style + '"></div>';
-			
+
 			// Add row to DataTable: object with start and end date
 			// note: subtract one from month since indexes from 0 to 11
-			data.addRow([new Date(userStart.substr(0,4), userStart.substr(5,2)-1, userStart.substr(8,2)), 
-						new Date(userEnd.substr(0,4), userEnd.substr(5,2)-1, userEnd.substr(8,2)),
+			data.addRow([new Date(userStart),
+						new Date(userEnd),
 						ocwBar ]);
 		}
-		
+
 		var options = {
 				"width": "100%",
 				"showCurrentTime": false,
 				"moveable": false,
 				"zoomable": false,
 		};
-		
-		// Draw timeline with data (DataTable) and options (a name-value map) 
+
+		// Draw timeline with data (DataTable) and options (a name-value map)
 		$rootScope.timeline.draw(data, options);
 	};
 

--- a/ocw-ui/frontend/app/scripts/controllers/worldmap.js
+++ b/ocw-ui/frontend/app/scripts/controllers/worldmap.js
@@ -41,7 +41,7 @@ function($rootScope, $scope, selectedDatasetInformation, regionSelectParams) {
 		// Don't process if we don't have any datasets added or if the map doesn't exist!!
 		if ($scope.datasets.length == 0 || !("map" in $rootScope))
 			return;
- 		
+
 		// Create a group that we'll draw overlays to
 		$rootScope.rectangleGroup = L.layerGroup();
 		// Add rectangle Group to map
@@ -78,7 +78,7 @@ function($rootScope, $scope, selectedDatasetInformation, regionSelectParams) {
 		$rootScope.rectangleGroup.addLayer(overlapBorder);
 
 		// Draw user selected region
-		if ($scope.regionParams.areValid) {
+		if (!isNaN($scope.regionParams.lonMin) && !isNaN($scope.regionParams.lonMax) && !isNaN($scope.regionParams.latMin) && !isNaN($scope.regionParams.latMax)) {
 
 			var bounds = [[$scope.regionParams.latMax, $scope.regionParams.lonMin],
 						  [$scope.regionParams.latMin, $scope.regionParams.lonMax]];

--- a/ocw-ui/frontend/app/views/main.html
+++ b/ocw-ui/frontend/app/views/main.html
@@ -113,10 +113,10 @@ under the License.
                 <div class="datasetNameDisplay col-md-8 col-md-offset-1 muted" tooltip="{{dataset.name}}">
                   {{dataset.name}}
                 </div>
-                <div class="col-md-1 col-md-offset-2">
-                  <span tooltip-placement="left" tooltip-popup-delay="700" tooltip="Remove Dataset">  
-                    <a class="no-color-link" href="#" ng-click="removeDataset($index)">
-                      <i class="fa fa-remove"></i>
+                <div class="col-md-2 col-md-offset-2">
+                  <span tooltip-placement="left" tooltip-popup-delay="700" tooltip="Remove Dataset">
+                    <a class="no-color-link pull-right" href="#" ng-click="removeDataset($index)">
+                        <i class="fa fa-times"/>
                     </a>
                   </span>
                 </div>
@@ -156,8 +156,8 @@ under the License.
                 <!--Preview Map Section-->
                 <div class="col-md-3">
                   <!--If the dataset is global we show a picture of a globe instead of the actual map-->
-                  <div ng-hide="dataset.latlonVals.lonMin == -180 && dataset.latlonVals.lonMax == 180 && 
-                                dataset.latlonVals.latMin == -90 && dataset.latlonVals.latMax == 90" 
+                  <div ng-hide="dataset.latlonVals.lonMin == -180 && dataset.latlonVals.lonMax == 180 &&
+                                dataset.latlonVals.latMin == -90 && dataset.latlonVals.latMax == 90"
                                 preview-map="dataset" index="$index"></div>
                   <div ng-show="dataset.latlonVals.lonMin == -180 && dataset.latlonVals.lonMax == 180 &&
                                 dataset.latlonVals.latMin == -90 && dataset.latlonVals.latMax == 90">
@@ -180,14 +180,14 @@ under the License.
             <leaflet-map id="map"></leaflet-map>
           </div>
         </div>
-        
+
         <!--Timeline-->
         <div class="row">
           <div class="col-md-12" ng-controller="TimelineCtrl">
             <div class="timeline"></div>
           </div>
         </div>
-        
+
         <div class="row">
           <div class="col-md-12" ng-controller="ParameterSelectCtrl">
             <div class="row top3">
@@ -196,7 +196,7 @@ under the License.
                 <form>
                   <!--This styling HAD to be done inline. Using a class wouldn't work and for some -->
                   <!--reason the input boxes refused to be 100% wide when their span size was set.-->
-                  <input ng-disabled="shouldDisableControls()" on-blur="checkParameters();" ng-model="displayParams.start" ui-date="datepickerSettings" ui-date-format="yy-mm-dd" type="text" class="col-md-4 text-center" style="width:100%" />
+                  <input ng-disabled="shouldDisableControls()" on-blur="checkParameters();" ng-model="displayParams.start" ui-date="datepickerSettings" type="text" class="col-md-4 text-center" style="width:100%" />
                 </form>
               </div>
               <div class="col-md-2 text-center">End Date:</div>
@@ -204,7 +204,7 @@ under the License.
                 <form>
                   <!--This styling HAD to be done inline. Using a class wouldn't work and for some -->
                   <!--reason the input boxes refused to be 100% wide when their span size was set.-->
-                  <input ng-disabled="shouldDisableControls()" on-blur="checkParameters();" ng-model="displayParams.end" ui-date="datepickerSettings" ui-date-format="yy-mm-dd" type="text" class="col-md-4 text-center" style="width:100%"/>
+                  <input ng-disabled="shouldDisableControls()" on-blur="checkParameters();" ng-model="displayParams.end" ui-date="datepickerSettings" type="text" class="col-md-4 text-center" style="width:100%"/>
                 </form>
               </div>
             </div>

--- a/ocw-ui/frontend/bower.json
+++ b/ocw-ui/frontend/bower.json
@@ -2,14 +2,14 @@
   "name": "ocw-ui",
   "version": "0.0.0",
   "dependencies": {
-    "angular": "1.2.16",
+    "angular": "~1.5.0",
     "json3": "~3.3.1",
     "es5-shim": "~3.1.0",
     "bootstrap": "~3.2.0",
-    "angular-resource": "1.2.16",
-    "angular-cookies": "1.2.16",
-    "angular-animate": "1.2.16",
-    "angular-route": "1.2.16",
+    "angular-resource": "~1.5.0",
+    "angular-cookies": "~1.5.0",
+    "angular-animate": "~1.5.0",
+    "angular-route": "~1.5.0",
     "angular-ui-router": "angular-ui/ui-router#~0.2.10",
     "leaflet": "~0.7.3",
     "chap-links-timeline": "~2.6.1",
@@ -18,8 +18,8 @@
     "angular-ui-date": "~0.0.3"
   },
   "devDependencies": {
-    "angular-mocks": "1.2.16",
-    "angular-scenario": "1.2.16"
+    "angular-mocks": "~1.5.0",
+    "angular-scenario": "~1.5.0"
   },
   "appPath": "app"
 }


### PR DESCRIPTION
CLIMATE-943 TypeError: Cannot set property uiDateValidator of undefined

- Upgraded to AngularJS 1.5 to fix error with date validator.
- Fixed issue in which date widget would not launch.
- Fixed issue in worldmap.js in which NaN lon / lat were processed which was throwing JavasScript error.
- Fixed issue in timeline.js in which undefined dates were process which was throwing JavasScript error.
- Fixed issue in which RCMED selection resets and throws JavaScript error.
- Removed explicit call to $scope.$apply(); which was throwing JavasScript error.
- Replace fa-remove with fa-times to restore missing dataset deletion icons.
- Changed copyright date to 2018.