### PR TITLE
CLIMATE-945 Grunt Errors On Build Task

### DIFF
--- a/ocw-ui/frontend/.jscsrc
+++ b/ocw-ui/frontend/.jscsrc
@@ -1,0 +1,17 @@
+{
+  "disallowTrailingWhitespace": true,
+  "disallowUnusedParams": true,
+  "disallowUnusedVariables": true,
+   "requireCapitalizedComments": true,
+  "requireCurlyBraces": true,
+  "requireDotNotation": true,
+  "requireLineFeedAtFileEnd": true,
+  "requireSemicolons": true,
+  "requireSpaceAfterComma": true,
+  "requireSpaceAfterLineComment": true,
+  "requireSpaceBetweenArguments": true,
+  "requireSpacesInConditionalExpression": true,
+  "requireTemplateStrings": true,
+  "requireYodaConditions": true,
+  "validateQuoteMarks": "'"
+}

--- a/ocw-ui/frontend/Gruntfile.js
+++ b/ocw-ui/frontend/Gruntfile.js
@@ -132,6 +132,14 @@ module.exports = function (grunt) {
       }
     },
 
+    // Supplements jshint with a focus on style.
+    jscs: {
+      src: '<%= yeoman.app %>/scripts/{,*/}*.js',
+      options: {
+        config: ".jscsrc",
+        fix: false
+      }
+    },
     // Empties folders to start fresh
     clean: {
       dist: {
@@ -408,6 +416,7 @@ module.exports = function (grunt) {
 
   grunt.registerTask('default', [
     'newer:jshint',
+    'jscs',
     'test',
     'build'
   ]);

--- a/ocw-ui/frontend/app/views/modelselect.html
+++ b/ocw-ui/frontend/app/views/modelselect.html
@@ -54,7 +54,7 @@ under the License.
             </div>
             <div class="control-group">
               <label class="control-label" for="lonSelect">Longitude Variable</label>
-              <div class"controls">
+              <div class="controls">
                 <select id="lonSelect">
                   <option ng-repeat="lon in lonVariables">
                     {{lon.text}}

--- a/ocw-ui/frontend/package.json
+++ b/ocw-ui/frontend/package.json
@@ -2,8 +2,8 @@
   "name": "ocwui",
   "version": "1.2.0",
   "description": "A tool for the evaluation and analysis of climate models.",
-  "repository": { 
-    "type" : "git", 
+  "repository": {
+    "type" : "git",
     "url" : "https://git-wip-us.apache.org/repos/asf/climate.git"
   },
   "license": "Apache-2.0",
@@ -14,6 +14,7 @@
     "generator-angular": "^0.9.5",
     "generator-karma": "^0.8.3",
     "grunt": "^0.4.1",
+    "grunt-jscs": "^3.0.1",
     "grunt-autoprefixer": "^0.7.3",
     "grunt-cli": "^0.1.13",
     "grunt-concurrent": "^0.5.0",
@@ -31,6 +32,7 @@
     "grunt-google-cdn": "^0.4.0",
     "grunt-karma": "^0.8.3",
     "grunt-newer": "^0.7.0",
+    "grunt-ngmin": "^0.0.3",
     "grunt-ng-annotate": "^0.1.0",
     "grunt-svgmin": "^0.4.0",
     "grunt-usemin": "^2.1.1",


### PR DESCRIPTION
CLIMATE-945 Grunt Errors On Build Task

- Fix htmlmin parsing error on ocw-ui/frontend/app/views/modelselect.html.
- Added missing dependency for npmin.
- Add jscs dependency and rule file to replace deprecated functionality in jshint.