### PR TITLE
CLIMATE-374 UI runEvaluation doesnt use $window or $location for resu…

### DIFF
--- a/ocw-ui/frontend/app/scripts/controllers/parameterselect.js
+++ b/ocw-ui/frontend/app/scripts/controllers/parameterselect.js
@@ -166,17 +166,17 @@ angular.module('ocwUiApp')
       data['lon_min'] = $scope.displayParams.lonMin,
       data['lon_max'] = $scope.displayParams.lonMax,
 
-      $http.post(`${$rootScope.baseURL}/processing/run_evaluation/`, data).
-      success((data) => {
-        const evalWorkDir = data.eval_work_dir;
+      $http.post($rootScope.baseURL + '/processing/run_evaluation/', data).
+      success(function(data) {
+        var evalWorkDir = data['eval_work_dir'];
 
         $scope.runningEval = false;
 
-        $timeout(() => {
-          let url = (evalWorkDir) ? `/results/${evalWorkDir}` : '/results';
+        $timeout(function() {
+          var url = (evalWorkDir) ? '/results/' + evalWorkDir : '/results';
           $location.url(url)
         }, 100);
-      }).error(() => {
+      }).error(function() {
         $scope.runningEval = false;
       });
     };

--- a/ocw-ui/frontend/app/scripts/controllers/parameterselect.js
+++ b/ocw-ui/frontend/app/scripts/controllers/parameterselect.js
@@ -27,9 +27,9 @@
  * Controller of the ocwUiApp
  */
 angular.module('ocwUiApp')
-.controller('ParameterSelectCtrl', ['$rootScope', '$scope', '$http', '$timeout', 
-						   'selectedDatasetInformation', 'regionSelectParams', 'evaluationSettings', 
-  function($rootScope, $scope, $http, $timeout, selectedDatasetInformation, regionSelectParams, evaluationSettings) {
+.controller('ParameterSelectCtrl', ['$rootScope', '$scope', '$http', '$timeout', '$location',
+						   'selectedDatasetInformation', 'regionSelectParams', 'evaluationSettings',
+  function($rootScope, $scope, $http, $timeout, $location, selectedDatasetInformation, regionSelectParams, evaluationSettings) {
     $scope.datasets = selectedDatasetInformation.getDatasets();
 
     // The min/max lat/lon values from the selected datasets
@@ -145,6 +145,8 @@ angular.module('ocwUiApp')
         data['temporal_resolution'] = 30;
       }
 
+      data['temporal_resolution_type'] = temporal_res;
+
       // Load the Metrics for the evaluation
       data['metrics'] = []
       var metrics = settings.metrics
@@ -164,21 +166,17 @@ angular.module('ocwUiApp')
       data['lon_min'] = $scope.displayParams.lonMin,
       data['lon_max'] = $scope.displayParams.lonMax,
 
-      $http.post($rootScope.baseURL + '/processing/run_evaluation/', data).
-      success(function(data) {
-        var evalWorkDir = data['eval_work_dir'];
+      $http.post(`${$rootScope.baseURL}/processing/run_evaluation/`, data).
+      success((data) => {
+        const evalWorkDir = data.eval_work_dir;
 
         $scope.runningEval = false;
 
-        $timeout(function() {
-          if (evalWorkDir !== undefined) {
-            window.location = "#/results/" + evalWorkDir;
-          } else {
-            window.location = "#/results";
-          }
+        $timeout(() => {
+          let url = (evalWorkDir) ? `/results/${evalWorkDir}` : '/results';
+          $location.url(url)
         }, 100);
-        
-      }).error(function() {
+      }).error(() => {
         $scope.runningEval = false;
       });
     };
@@ -192,13 +190,13 @@ angular.module('ocwUiApp')
       if (parseFloat($scope.displayParams.latMax) > parseFloat($scope.latMax))
         $scope.displayParams.latMax = $scope.latMax;
 
-      if (parseFloat($scope.displayParams.lonMin) < parseFloat($scope.lonMin)) 
+      if (parseFloat($scope.displayParams.lonMin) < parseFloat($scope.lonMin))
         $scope.displayParams.lonMin = $scope.lonMin;
 
-      if (parseFloat($scope.displayParams.lonMax) > parseFloat($scope.lonMax)) 
+      if (parseFloat($scope.displayParams.lonMax) > parseFloat($scope.lonMax))
         $scope.displayParams.lonMax = $scope.lonMax;
 
-      if ($scope.displayParams.start < $scope.start) 
+      if ($scope.displayParams.start < $scope.start)
         $scope.displayParams.start = $scope.start;
 
       if ($scope.displayParams.end > $scope.end)
@@ -213,8 +211,8 @@ angular.module('ocwUiApp')
       $rootScope.$broadcast('redrawOverlays', []);
     }
 
-    $scope.unwatchDatasets = $scope.$watch('datasets', 
-      function() { 
+    $scope.unwatchDatasets = $scope.$watch('datasets',
+      function() {
         var numDatasets = $scope.datasets.length;
         $scope.displayParams.areValid = false;
         $scope.areInUserRegridState = false;
@@ -230,7 +228,7 @@ angular.module('ocwUiApp')
           // Get the valid lat/lon range in the selected datasets.
           for (var i = 0; i < numDatasets; i++) {
             var curDataset = $scope.datasets[i];
-    
+
             latMin = (curDataset['latlonVals']['latMin'] > latMin) ? curDataset['latlonVals']['latMin'] : latMin;
             latMax = (curDataset['latlonVals']['latMax'] < latMax) ? curDataset['latlonVals']['latMax'] : latMax;
             lonMin = (curDataset['latlonVals']['lonMin'] > lonMin) ? curDataset['latlonVals']['lonMin'] : lonMin;


### PR DESCRIPTION
CLIMATE-374 UI runEvaluation doesnt use $window or $location for results transition

- Updated to use $location rather than window.location to transition the input page to the results page.