### PR TITLE
Climate 964

### DIFF
--- a/examples/simple_model_to_model_bias.py
+++ b/examples/simple_model_to_model_bias.py
@@ -73,6 +73,7 @@ FILE_2 = "AFRICA_UC-WRF311_CTL_ERAINT_MM_50km-rg_1989-2008_tasmax.nc"
 # Filename for the output image/plot (without file extension)
 OUTPUT_PLOT = "wrf_bias_compared_to_knmi"
 
+# Retrieve the local model files into the OS-aware temp directory.
 tempdir = tempfile.gettempdir()
 FILE_1_PATH = path.join(tempdir, FILE_1)
 FILE_2_PATH = path.join(tempdir, FILE_2)

--- a/examples/simple_model_to_model_bias.py
+++ b/examples/simple_model_to_model_bias.py
@@ -55,6 +55,7 @@ import ocw.dataset_processor as dsp
 import ocw.evaluation as evaluation
 import ocw.metrics as metrics
 import ocw.plotter as plotter
+import tempfile
 
 if sys.version_info[0] >= 3:
     from urllib.request import urlretrieve
@@ -72,8 +73,9 @@ FILE_2 = "AFRICA_UC-WRF311_CTL_ERAINT_MM_50km-rg_1989-2008_tasmax.nc"
 # Filename for the output image/plot (without file extension)
 OUTPUT_PLOT = "wrf_bias_compared_to_knmi"
 
-FILE_1_PATH = path.join('/tmp', FILE_1)
-FILE_2_PATH = path.join('/tmp', FILE_2)
+tempdir = tempfile.gettempdir()
+FILE_1_PATH = path.join(tempdir, FILE_1)
+FILE_2_PATH = path.join(tempdir, FILE_2)
 
 if not path.exists(FILE_1_PATH):
     urlretrieve(FILE_LEADER + FILE_1, FILE_1_PATH)


### PR DESCRIPTION
The local model files are not downloaded to the temp directory in Windows since the "tmp" directory was introduced in CLIMATE 603.  In order to make the downloads work on Windows as well as Linux (and Mac), this pull request uses tempfile.gettempdir()  identify the optimal temp file location for that operating system.

I am new to this project so I have not yet run the test suite, though I have tested locally.