### PR TITLE
CLIMATE-965 - Add an option to compare climatologies between climate models and observations

### DIFF
--- a/RCMES/CORDEX/templates/CORDEX_evaluation_run.yaml.template
+++ b/RCMES/CORDEX/templates/CORDEX_evaluation_run.yaml.template
@@ -10,7 +10,7 @@ output_netcdf_filename: {{ basename }}.nc
 time:
     maximum_overlap_period: True
     temporal_resolution: monthly
-    adjust_model_years_for_climatology_calculation: True  
+    adjust_model_years_for_climatology_calculation: False 
 {% if season == "winter" %}
     month_start: 12
     month_end: 2

--- a/RCMES/run_RCMES.py
+++ b/RCMES/run_RCMES.py
@@ -125,6 +125,9 @@ for i, dataset in enumerate(datasets):
 
 """ Step 2: Subset the data for temporal and spatial domain """
 # Create a Bounds object to use for subsetting
+if 'adjust_model_years_for_climatology_calculation' in time_info:
+    if time_info['adjust_model_years_for_climatology_calculation']:
+        datasets = utils.adjust_model_years_for_climatology_calculation(datasets) 
 if maximum_overlap_period:
     start_time, end_time = utils.get_temporal_overlap(datasets)
     print('Maximum overlap period')

--- a/ocw/utils.py
+++ b/ocw/utils.py
@@ -383,8 +383,6 @@ def get_temporal_overlap(dataset_array):
     ''' Find the maximum temporal overlap across the observation and model datasets
 
     :param dataset_array: an array of OCW datasets
-    :param idx: start and end indices to denote subset of months used.
-    :type idx: class:`tuple`
     '''
     start_times = []
     end_times = []
@@ -397,6 +395,19 @@ def get_temporal_overlap(dataset_array):
 
     return np.max(start_times), np.min(end_times)
 
+def adjust_model_years_for_climatology_calculation(dataset_array):
+    ''' Using the time length of the first element in the input dataset_array, 
+        adjust years in the rest ofi the dataset_array so that every dataset ends in the same year.
+    :param dataset_array: an array of OCW datasets
+    '''
+    slc = trim_dataset(dataset_array[0])
+    obs_times = dataset_array[0].times[slc]
+    for idata, dataset in enumerate(dataset_array[1:]):
+        year_diff = obs_times[-1].year - dataset.times[-1].year    
+        nt = dataset.times.size
+        for it in np.arange(nt):
+            dataset.times[it] = dataset.times[it].replace(year = dataset.times[it].year + year_diff)
+    return dataset_array                              
 
 def trim_dataset(dataset):
     ''' Trim datasets such that first and last year of data have all 12 months


### PR DESCRIPTION
- When evaluating GCMs and RCMs forced by GCMs, the added option, 'adjust_model_years_for_climatology_calculation', allows users to calculate climatologies ignoring temporal overlap. 